### PR TITLE
fix: Downgrade litellm version because of install error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "uvicorn>=0.29.0",
     "pydantic>=2.6.0",
     "python-dotenv>=1.0.0",
-    "litellm>=1.0.0",
+    "litellm<1.77.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -250,7 +250,7 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "litellm", specifier = ">=1.0.0" },
+    { name = "litellm", specifier = "<1.77.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.13.1" },
     { name = "pydantic", specifier = ">=2.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },


### PR DESCRIPTION
   - litellm > 1.77.0 has a breaking issue for install.
   - Temporarily downgrade to < 1.77.0