### PR TITLE
feat: include import statements in behavioral analysis

### DIFF
--- a/mcpscanner/core/analyzers/behavioral/alignment/alignment_prompt_builder.py
+++ b/mcpscanner/core/analyzers/behavioral/alignment/alignment_prompt_builder.py
@@ -116,7 +116,18 @@ class AlignmentPromptBuilder:
 **FUNCTION SIGNATURE:**
 - Parameters: {json.dumps(func_context.parameters, indent=2)}
 - Return Type: {func_context.return_type or 'Not specified'}
-
+""")
+        
+        # Add imports section
+        if func_context.imports:
+            import_parts = ["\n**IMPORTS:**\n"]
+            import_parts.append("The following libraries and modules are imported:\n")
+            for imp in func_context.imports:
+                import_parts.append(f"  {imp}\n")
+            import_parts.append("\n")
+            content_parts.append(''.join(import_parts))
+        
+        content_parts.append("""
 **DATAFLOW ANALYSIS:**
 All parameters are treated as untrusted input (MCP entry points receive external data).
 


### PR DESCRIPTION
- Updated context_extractor.py to extract both module-level and function-level imports
- Added import aliases support (e.g., 'import pandas as pd')
- Updated alignment_prompt_builder.py to include IMPORTS section in LLM prompt
- Imports now provide critical context for threat detection (network libs, file ops, code execution)