### PR TITLE
ci(cisco-ai-defense-mcp-scanner): add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,30 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@47895cf40f6214511c713628dbbafd0c3316f4dd
+        with:
+          mode: validate
+          skill-dir: claude-code-plugin/skills/security-scan
+          annotate: "false"
+          preview-upload: "false"


### PR DESCRIPTION
Adding a metadata validation workflow to complement the existing CI setup.

- Scans MCP tools, prompts, resources, and server instructions for security findings
- Scans source code of MCP servers for finding threats

This PR adds one workflow at `.github/workflows/hol-skill-validate.yml` which runs the HOL skill validator in validate mode. It checks schema and trust signals only, stays validate-only, and leaves runtime code untouched.

Happy to rename the workflow file or adjust the skill directory if you prefer a different structure.