### PR TITLE
feat: Add MCP schema linter with 37 built-in rules and lint CLI subco…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This directory contains detailed documentation for the MCP Scanner SDK.
 - **[Architecture](architecture.md)** - System architecture, components, and data models
 - **[Behavioral Scanning](behavioral-scanning.md)** - Advanced static analysis with LLM-powered alignment checking
 - **[Readiness Scanning](readiness-scanning.md)** - Zero-dependency production readiness analysis with 20 heuristic rules
+- **[Schema Linting](schema-linting.md)** - Rule-driven quality validation for MCP tool, prompt, and resource schemas (37 rules)
 - **[LLM Providers](llm-providers.md)** - Configuration guide for all LLM providers (OpenAI, Azure, AWS Bedrock, etc.)
 - **[MCP Threats Taxonomy](mcp-threats-taxonomy.md)** - Complete AITech/AISubtech threat taxonomy
 - **[Authentication](authentication.md)** - OAuth setup, explicit auth control, and security configuration

--- a/docs/design/mcp-schema-linter-design.md
+++ b/docs/design/mcp-schema-linter-design.md
@@ -1,0 +1,96 @@
+# MCP Schema Linter — Design Document
+
+## Motivation
+
+MCP-scanner focuses on security and vulnerability scanning, but there is no quality validation step to catch MCP schema issues early (missing descriptions, inconsistent naming, incomplete documentation, structural gaps). Without early validation, these issues surface late — during agent execution, integration testing, or code review.
+
+Based on patterns from API ecosystems (Spectral for OpenAPI, vacuum), a linting-style validator surfaces quality and correctness issues before runtime.
+
+## Architecture
+
+The linter is a self-contained module under `mcpscanner/core/analyzers/linter/` with its own finding type and output formatter. It connects to MCP servers using the existing MCP SDK but runs a separate validation pipeline.
+
+### Components
+
+```
+mcpscanner/core/analyzers/linter/
+├── __init__.py       # Public API exports
+├── engine.py         # LintEngine: orchestrates rules, collects findings
+├── finding.py        # LintFinding, LintSeverity, LintSummary data classes
+├── rule.py           # LintRule ABC, RuleRegistry
+├── formatter.py      # Table/JSON/summary output formatters
+├── rulesets.py       # Predefined rulesets (recommended, strict, quality)
+├── config.py         # YAML config loader for rule overrides
+└── rules/            # Built-in rules grouped by category
+    ├── tool_rules.py
+    ├── prompt_rules.py
+    ├── resource_rules.py
+    └── server_rules.py
+```
+
+### Data Flow
+
+1. CLI parses `lint` subcommand arguments
+2. MCP connection established (remote/stdio) or static files loaded
+3. Tool/prompt/resource schemas converted to plain dicts
+4. `LintEngine` runs active rules from `RuleRegistry` against each item
+5. Server-level rules run against the aggregate
+6. Findings sorted by severity, summarized into `LintSummary`
+7. `LintFormatter` renders output (table, summary, or JSON)
+
+## Design Decisions
+
+### Standalone finding type vs SecurityFinding
+
+The linter uses `LintFinding` instead of `SecurityFinding` because:
+- Lint findings have different semantics (quality, not security)
+- Different severity levels (error/warning/info/hint vs HIGH/MEDIUM/LOW)
+- Different output format requirements (rule ID, recommendation, affected items)
+- Clean separation avoids overloading security reporting pipelines
+
+### Rule architecture
+
+Rules follow the declarative pattern from `prompt_defense_analyzer.py`:
+- Each rule is a class extending `LintRule` with a `check()` method
+- Rules are stateless and produce `LintFinding` lists
+- A `RuleRegistry` manages enable/disable and severity overrides
+- Severity overrides are applied on copies to avoid shared state mutation
+
+### Rulesets
+
+Three predefined rulesets cover different use cases:
+- `recommended`: sensible defaults for development
+- `strict`: CI enforcement (info promoted to warning)
+- `quality`: documentation-focused subset
+
+### 37 rules
+
+Rules are grouped by the MCP concept they validate:
+- 18 tool rules (schema structure, naming, documentation)
+- 8 prompt rules (metadata, arguments)
+- 6 resource rules (URI, MIME type, naming)
+- 5 server rules (uniqueness, capabilities, limits)
+
+## Integration Points
+
+| Area | What was added |
+|------|----------------|
+| `AnalyzerEnum` | `LINT = "lint"` in `models.py` |
+| Package exports | `LintEngine` in `analyzers/__init__.py` |
+| CLI | `lint` subparser in `cli.py` with dedicated handler |
+| MCP connection | Reuses MCP SDK directly for schema fetching |
+
+## Testing
+
+178 unit tests organized by component:
+- Per-rule tests (tool, prompt, resource, server)
+- Engine orchestration tests (rulesets, summary accuracy)
+- Formatter tests (table, summary, JSON output)
+- CLI integration tests (static file linting, ruleset behavior)
+
+## Future Work
+
+- Additional rules for MCP-specific patterns (e.g., timeout/retry metadata)
+- Integration with readiness analyzer for cross-cutting validation
+- Custom rule plugins loaded from external packages
+- IDE integration (LSP-based real-time linting)

--- a/docs/schema-linting.md
+++ b/docs/schema-linting.md
@@ -1,0 +1,221 @@
+# MCP Schema Linting
+
+The `lint` subcommand validates MCP tool, prompt, and resource schemas for quality, completeness, and consistency. It surfaces issues early — before runtime or security scanning — using a rule-driven validation model.
+
+## Quick Start
+
+```bash
+# Lint a remote MCP server
+mcp-scanner lint --server-url https://mcp.deepwiki.com/mcp
+
+# Lint a stdio server
+mcp-scanner lint --stdio-command "npx -y @example/mcp-server"
+
+# Lint from static JSON files (offline)
+mcp-scanner lint --tools-file tools.json
+mcp-scanner lint --tools-file tools.json --prompts-file prompts.json
+
+# Use a stricter ruleset
+mcp-scanner lint --server-url https://mcp.example.com/mcp --ruleset strict
+
+# JSON output for CI/CD
+mcp-scanner lint --server-url https://mcp.example.com/mcp --format json
+```
+
+## Output Formats
+
+### Table (default)
+
+```
+Tool Quality
+    #  SEVERITY  CODE                                 FINDINGS                        RECOMMENDATION                                 AFFECTED ITEMS
+    1  info      tool-schema-has-examples             Tool 'read_wiki_structure'      Add 'example' field to properties for better          3
+                                                      properties missing examples:    documentation
+                                                      repoName
+    2  info      tool-output-schema-defined           Tool 'read_wiki_structure' has  Add an outputSchema to define the structure           3
+                                                      no outputSchema defined         of tool results
+2 Findings (0 Error, 0 Warning, 2 Info, 0 Hint)
+  # | CATEGORY     | ERROR | WARNING | INFO | HINT
+  -----------------------------------------------------------
+  1 | Tool         |     0 |       0 |    6 |    0
+
+============================================================
+Summary
+  Scanned:       3 tools
+  Rules checked: 37
+  Rules passed:  35 (94%)
+  Rules failed:  2
+  Total issues:  6
+```
+
+### Summary
+
+A compact overview of scanned items, rules checked, and issue counts.
+
+### JSON
+
+Machine-readable output for CI/CD pipelines:
+
+```json
+{
+  "target": "https://mcp.example.com/mcp",
+  "tools_scanned": 3,
+  "prompts_scanned": 0,
+  "resources_scanned": 0,
+  "rules_checked": 37,
+  "rules_passed": 35,
+  "rules_failed": 2,
+  "total_findings": 6,
+  "findings_by_severity": {"info": 6},
+  "findings_by_category": {"tool": 6},
+  "findings": [
+    {
+      "rule_id": "tool-schema-has-examples",
+      "severity": "info",
+      "category": "tool",
+      "message": "Tool 'read_wiki_structure' properties missing examples: repoName",
+      "recommendation": "Add 'example' field to properties for better documentation",
+      "item_name": "read_wiki_structure",
+      "affected_items": 1,
+      "location": "inputSchema.properties"
+    }
+  ]
+}
+```
+
+## Built-in Rules (37)
+
+### Tool Rules (18)
+
+| ID | Default Severity | Description |
+|----|-----------------|-------------|
+| `tool-has-name` | error | Tool must have a non-empty name |
+| `tool-has-description` | warning | Tool must have a description |
+| `tool-description-min-length` | info | Description should be at least 20 characters |
+| `tool-description-not-name` | warning | Description should not just repeat the name |
+| `tool-name-convention` | info | Name should follow snake_case or camelCase |
+| `tool-name-max-length` | info | Name should be under 64 characters |
+| `tool-has-input-schema` | warning | Tool should define an inputSchema |
+| `tool-input-schema-has-properties` | warning | inputSchema should define properties |
+| `tool-input-schema-has-required` | info | inputSchema should declare required fields |
+| `tool-required-params-defined` | error | Required params must exist in properties |
+| `tool-schema-properties-have-types` | warning | Each property should have a type |
+| `tool-schema-properties-have-descriptions` | info | Each property should have a description |
+| `tool-schema-has-examples` | info | Properties should include examples |
+| `tool-output-schema-defined` | info | Tool should define an outputSchema |
+| `tool-no-empty-enum` | warning | Enum properties must have values |
+| `tool-schema-max-depth` | warning | Schema nesting should not exceed depth 5 |
+| `tool-no-duplicate-params` | error | No duplicate property names in schema |
+| `tool-description-no-html` | info | Description should not contain HTML tags |
+
+### Prompt Rules (8)
+
+| ID | Default Severity | Description |
+|----|-----------------|-------------|
+| `prompt-has-name` | error | Prompt must have a non-empty name |
+| `prompt-has-description` | warning | Prompt must have a description |
+| `prompt-description-min-length` | info | Description should be at least 20 characters |
+| `prompt-name-convention` | info | Name should follow a consistent convention |
+| `prompt-has-arguments` | info | Prompt should define arguments |
+| `prompt-argument-has-description` | info | Each argument should have a description |
+| `prompt-argument-has-required` | info | Arguments should specify required flag |
+| `prompt-no-duplicate-arguments` | error | No duplicate argument names |
+
+### Resource Rules (6)
+
+| ID | Default Severity | Description |
+|----|-----------------|-------------|
+| `resource-has-name` | error | Resource must have a non-empty name |
+| `resource-has-description` | warning | Resource should have a description |
+| `resource-has-mime-type` | warning | Resource should specify a MIME type |
+| `resource-mime-type-valid` | warning | MIME type should be valid format |
+| `resource-uri-valid` | info | URI should be well-formed |
+| `resource-name-convention` | info | Name should follow a consistent convention |
+
+### Server Rules (5)
+
+| ID | Default Severity | Description |
+|----|-----------------|-------------|
+| `server-has-capabilities` | warning | Server should expose tools, prompts, or resources |
+| `server-tool-names-unique` | error | All tool names must be unique |
+| `server-prompt-names-unique` | error | All prompt names must be unique |
+| `server-resource-uris-unique` | error | All resource URIs must be unique |
+| `server-no-excessive-tools` | info | Server should not expose more than 100 tools |
+
+## Rulesets
+
+### `recommended` (default)
+
+All 37 rules at their default severities. Good for everyday development.
+
+### `strict`
+
+All rules enabled with `info` rules promoted to `warning`. Use in CI/CD for stricter enforcement.
+
+### `quality`
+
+Only documentation and completeness rules (descriptions, examples, outputSchema). Use for focused documentation quality checks.
+
+## Configuration
+
+Create a `.mcp-lint.yaml` file to customize rules:
+
+```yaml
+extends: recommended
+rules:
+  tool-output-schema-defined: off
+  tool-description-min-length: warning
+  tool-schema-has-examples: warning
+```
+
+Use it with:
+
+```bash
+mcp-scanner lint --server-url <url> --lint-config .mcp-lint.yaml
+```
+
+### Override values
+
+- `off` — disable the rule entirely
+- `error`, `warning`, `info`, `hint` — override the severity level
+
+## Programmatic Usage
+
+```python
+from mcpscanner.core.analyzers.linter import LintEngine, LintFormatter
+
+engine = LintEngine(ruleset="recommended")
+
+tools = [
+    {
+        "name": "get_user",
+        "description": "Fetches a user by ID",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "user_id": {"type": "string", "description": "User ID"}
+            },
+            "required": ["user_id"],
+        },
+    }
+]
+
+summary = engine.lint(tools=tools, target="my-server")
+
+formatter = LintFormatter(summary)
+print(formatter.format_table())
+print(formatter.format_json())
+```
+
+## CI/CD Integration
+
+Use `--format json` and parse the output to fail builds on errors:
+
+```bash
+result=$(mcp-scanner lint --server-url "$MCP_URL" --format json)
+errors=$(echo "$result" | jq '.findings_by_severity.error // 0')
+if [ "$errors" -gt 0 ]; then
+  echo "Lint failed with $errors errors"
+  exit 1
+fi
+```

--- a/mcpscanner/cli.py
+++ b/mcpscanner/cli.py
@@ -863,6 +863,176 @@ def display_instructions_results(
             print()
 
 
+async def _handle_lint(args):
+    """Handle the 'lint' subcommand."""
+    import json as _json
+    from pathlib import Path
+
+    from mcpscanner.core.analyzers.linter import LintEngine, LintFormatter
+    from mcpscanner.core.analyzers.linter.config import LintConfig
+
+    tools = []
+    prompts = []
+    resources = []
+    target = ""
+
+    lint_config = LintConfig.load(getattr(args, "lint_config", None))
+    ruleset = getattr(args, "ruleset", None) or lint_config.extends
+
+    if getattr(args, "tools_file", None) or getattr(args, "prompts_file", None) or getattr(args, "resources_file", None):
+        target = "static"
+        if args.tools_file:
+            target = args.tools_file
+            p = Path(args.tools_file)
+            if p.is_file():
+                data = _json.loads(p.read_text())
+                tools = data.get("tools", data) if isinstance(data, dict) else data
+        if args.prompts_file:
+            p = Path(args.prompts_file)
+            if p.is_file():
+                data = _json.loads(p.read_text())
+                prompts = data.get("prompts", data) if isinstance(data, dict) else data
+        if args.resources_file:
+            p = Path(args.resources_file)
+            if p.is_file():
+                data = _json.loads(p.read_text())
+                resources = data.get("resources", data) if isinstance(data, dict) else data
+
+    elif getattr(args, "server_url", None):
+        target = args.server_url
+        tools, prompts, resources = await _fetch_mcp_schemas_remote(args)
+
+    elif getattr(args, "stdio_command", None):
+        target = f"stdio:{args.stdio_command}"
+        tools, prompts, resources = await _fetch_mcp_schemas_stdio(args)
+
+    else:
+        print("Error: provide --server-url, --stdio-command, or --tools-file for linting")
+        return
+
+    engine = LintEngine(config=lint_config, ruleset=ruleset)
+    summary = engine.lint(tools=tools, prompts=prompts, resources=resources, target=target)
+
+    fmt = getattr(args, "format", "table")
+    formatter = LintFormatter(summary)
+    output = formatter.format(fmt)
+    print(output)
+
+    if getattr(args, "output", None):
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(formatter.format_json() if fmt != "json" else output)
+        print(f"Results saved to {args.output}")
+
+
+async def _fetch_mcp_schemas_remote(args):
+    """Connect to a remote MCP server and fetch tool/prompt/resource schemas."""
+    from mcp.client.session import ClientSession
+    from mcp.client.sse import sse_client
+    from mcp.client.streamable_http import streamable_http_client, create_mcp_http_client
+
+    server_url = args.server_url
+    headers = {}
+    for h in getattr(args, "header", []) or []:
+        if ":" in h:
+            k, v = h.split(":", 1)
+            headers[k.strip()] = v.strip()
+    if getattr(args, "bearer_token", None):
+        headers["Authorization"] = f"Bearer {args.bearer_token}"
+
+    extra_headers = headers if headers else None
+
+    if "/sse" in server_url:
+        client_ctx = sse_client(server_url, headers=extra_headers) if extra_headers else sse_client(server_url)
+    else:
+        http_client = create_mcp_http_client(headers=extra_headers) if extra_headers else create_mcp_http_client()
+        client_ctx = streamable_http_client(server_url, http_client=http_client)
+
+    async with client_ctx as streams:
+        read, write, *_ = streams
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            tools = []
+            prompts = []
+            resources = []
+
+            try:
+                tool_list = await session.list_tools()
+                tools = [_json_loads_model(t) for t in tool_list.tools]
+            except Exception:
+                pass
+
+            try:
+                prompt_list = await session.list_prompts()
+                prompts = [_json_loads_model(p) for p in prompt_list.prompts]
+            except Exception:
+                pass
+
+            try:
+                resource_list = await session.list_resources()
+                resources = [_json_loads_model(r) for r in resource_list.resources]
+            except Exception:
+                pass
+
+            return tools, prompts, resources
+
+
+async def _fetch_mcp_schemas_stdio(args):
+    """Connect to a stdio MCP server and fetch tool/prompt/resource schemas."""
+    import os
+    import sys
+
+    from mcp import StdioServerParameters
+    from mcp.client.session import ClientSession
+    from mcp.client.stdio import stdio_client
+
+    stdio_args = []
+    if getattr(args, "stdio_args", ""):
+        stdio_args.extend([a for a in args.stdio_args.split(",") if a])
+    if getattr(args, "stdio_arg", None):
+        stdio_args.extend(args.stdio_arg)
+
+    server_params = StdioServerParameters(
+        command=args.stdio_command,
+        args=stdio_args,
+        env={**os.environ},
+    )
+
+    async with stdio_client(server_params, errlog=sys.stderr) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            tools = []
+            prompts = []
+            resources = []
+
+            try:
+                tool_list = await session.list_tools()
+                tools = [_json_loads_model(t) for t in tool_list.tools]
+            except Exception:
+                pass
+
+            try:
+                prompt_list = await session.list_prompts()
+                prompts = [_json_loads_model(p) for p in prompt_list.prompts]
+            except Exception:
+                pass
+
+            try:
+                resource_list = await session.list_resources()
+                resources = [_json_loads_model(r) for r in resource_list.resources]
+            except Exception:
+                pass
+
+            return tools, prompts, resources
+
+
+def _json_loads_model(obj):
+    """Convert an MCP SDK model to a plain dict via JSON round-trip."""
+    import json as _json
+    return _json.loads(obj.model_dump_json())
+
+
 async def main():
     """Main entry point for the script."""
     parser = argparse.ArgumentParser(
@@ -1130,6 +1300,72 @@ async def main():
     p_known_configs.add_argument(
         "--bearer-token",
         help="Bearer token for authentication",
+    )
+
+    # Lint subcommand - MCP schema quality validation
+    p_lint = subparsers.add_parser(
+        "lint",
+        help="Validate MCP tool/prompt/resource schemas for quality and completeness",
+    )
+    p_lint.add_argument(
+        "--server-url",
+        help="URL of the MCP server to lint",
+    )
+    p_lint.add_argument(
+        "--stdio-command",
+        help="Command to run a stdio-based MCP server for linting",
+    )
+    p_lint.add_argument(
+        "--stdio-args",
+        type=str,
+        default="",
+        help="Arguments for the stdio command (comma-separated)",
+    )
+    p_lint.add_argument(
+        "--stdio-arg",
+        action="append",
+        help="Repeatable single argument for stdio command",
+    )
+    p_lint.add_argument(
+        "--tools-file",
+        help="Path to a JSON file with MCP tool definitions for offline linting",
+    )
+    p_lint.add_argument(
+        "--prompts-file",
+        help="Path to a JSON file with MCP prompt definitions for offline linting",
+    )
+    p_lint.add_argument(
+        "--resources-file",
+        help="Path to a JSON file with MCP resource definitions for offline linting",
+    )
+    p_lint.add_argument(
+        "--ruleset",
+        choices=["recommended", "strict", "quality"],
+        default="recommended",
+        help="Predefined ruleset (default: %(default)s)",
+    )
+    p_lint.add_argument(
+        "--lint-config",
+        help="Path to YAML config for rule overrides",
+    )
+    p_lint.add_argument(
+        "--format",
+        choices=["table", "summary", "json"],
+        default="table",
+        help="Output format (default: %(default)s)",
+    )
+    p_lint.add_argument(
+        "--output", "-o", help="Save lint results to a file",
+    )
+    p_lint.add_argument(
+        "--header",
+        action="append",
+        default=[],
+        help="Custom HTTP header in 'Key: Value' format for remote servers",
+    )
+    p_lint.add_argument(
+        "--bearer-token",
+        help="Bearer token for remote MCP server authentication",
     )
 
     # API key and endpoint configuration
@@ -1950,6 +2186,10 @@ async def main():
                     json.dump(results, f, indent=2)
                 if args.verbose:
                     print(f"Results saved to {args.output}")
+
+        elif hasattr(args, "cmd") and args.cmd == "lint":
+            await _handle_lint(args)
+            return
 
         # Backward compatibility path (no subcommand used)
         elif args.stdio_command:

--- a/mcpscanner/core/analyzers/__init__.py
+++ b/mcpscanner/core/analyzers/__init__.py
@@ -30,6 +30,7 @@ from .yara_analyzer import YaraAnalyzer
 from .virustotal_analyzer import VirusTotalAnalyzer
 from .prompt_defense_analyzer import PromptDefenseAnalyzer
 from .readiness import ReadinessAnalyzer, ReadinessLLMJudge, OpaProvider
+from .linter import LintEngine
 
 __all__ = [
     "BaseAnalyzer",
@@ -44,4 +45,5 @@ __all__ = [
     "ReadinessAnalyzer",
     "ReadinessLLMJudge",
     "OpaProvider",
+    "LintEngine",
 ]

--- a/mcpscanner/core/analyzers/linter/__init__.py
+++ b/mcpscanner/core/analyzers/linter/__init__.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""MCP schema linter — rule-driven quality validation for MCP tool, prompt, and resource schemas."""
+
+from .engine import LintEngine
+from .finding import LintFinding, LintSeverity
+from .formatter import LintFormatter
+from .rule import LintRule, RuleRegistry
+
+__all__ = [
+    "LintEngine",
+    "LintFinding",
+    "LintFormatter",
+    "LintRule",
+    "LintSeverity",
+    "RuleRegistry",
+]

--- a/mcpscanner/core/analyzers/linter/config.py
+++ b/mcpscanner/core/analyzers/linter/config.py
@@ -1,0 +1,61 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Lint configuration loader (YAML-based)."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LintConfig:
+    """Configuration for the MCP schema linter."""
+
+    extends: str = "recommended"
+    rules: Dict[str, str] = field(default_factory=dict)
+
+    @classmethod
+    def from_file(cls, path: str) -> "LintConfig":
+        """Load lint configuration from a YAML file."""
+        import yaml  # deferred import — yaml is optional
+
+        config_path = Path(path)
+        if not config_path.is_file():
+            logger.warning("Lint config file not found: %s", path)
+            return cls()
+
+        with open(config_path) as f:
+            data: Dict[str, Any] = yaml.safe_load(f) or {}
+
+        return cls(
+            extends=data.get("extends", "recommended"),
+            rules=data.get("rules", {}),
+        )
+
+    @classmethod
+    def default(cls) -> "LintConfig":
+        return cls()
+
+    @classmethod
+    def load(cls, config_path: Optional[str] = None) -> "LintConfig":
+        if config_path:
+            return cls.from_file(config_path)
+        return cls.default()

--- a/mcpscanner/core/analyzers/linter/engine.py
+++ b/mcpscanner/core/analyzers/linter/engine.py
@@ -1,0 +1,118 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Lint engine — orchestrates rules against MCP schema data."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from .config import LintConfig
+from .finding import LintFinding, LintSeverity, LintSummary
+from .rule import RuleRegistry
+from .rulesets import build_registry
+
+logger = logging.getLogger(__name__)
+
+
+class LintEngine:
+    """Run lint rules against MCP tools, prompts, and resources."""
+
+    def __init__(
+        self,
+        config: Optional[LintConfig] = None,
+        ruleset: str = "recommended",
+        registry: Optional[RuleRegistry] = None,
+    ):
+        cfg = config or LintConfig.default()
+        effective_ruleset = ruleset if ruleset != "recommended" else cfg.extends
+        self.registry = registry or build_registry(
+            ruleset=effective_ruleset,
+            overrides=cfg.rules or None,
+        )
+
+    def lint(
+        self,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        prompts: Optional[List[Dict[str, Any]]] = None,
+        resources: Optional[List[Dict[str, Any]]] = None,
+        target: str = "",
+    ) -> LintSummary:
+        """Run all active rules and return a LintSummary."""
+        tools = tools or []
+        prompts = prompts or []
+        resources = resources or []
+
+        all_findings: List[LintFinding] = []
+        rules_that_fired: set[str] = set()
+        context: Dict[str, Any] = {"target": target}
+
+        for tool in tools:
+            for rule in self.registry.get_active_rules(category="tool"):
+                findings = rule.check(tool, context)
+                if findings:
+                    rules_that_fired.add(rule.id)
+                all_findings.extend(findings)
+
+        for prompt in prompts:
+            for rule in self.registry.get_active_rules(category="prompt"):
+                findings = rule.check(prompt, context)
+                if findings:
+                    rules_that_fired.add(rule.id)
+                all_findings.extend(findings)
+
+        for resource in resources:
+            for rule in self.registry.get_active_rules(category="resource"):
+                findings = rule.check(resource, context)
+                if findings:
+                    rules_that_fired.add(rule.id)
+                all_findings.extend(findings)
+
+        server_data: Dict[str, Any] = {
+            "tools": tools,
+            "prompts": prompts,
+            "resources": resources,
+        }
+        for rule in self.registry.get_active_rules(category="server"):
+            findings = rule.check(server_data, context)
+            if findings:
+                rules_that_fired.add(rule.id)
+            all_findings.extend(findings)
+
+        all_findings.sort(key=lambda f: f.severity.rank)
+
+        rules_checked = self.registry.active_count
+        rules_failed = len(rules_that_fired)
+
+        sev_counts: Dict[str, int] = {}
+        cat_counts: Dict[str, int] = {}
+        for f in all_findings:
+            sev_counts[f.severity.value] = sev_counts.get(f.severity.value, 0) + 1
+            cat_counts[f.category] = cat_counts.get(f.category, 0) + 1
+
+        return LintSummary(
+            target=target,
+            tools_scanned=len(tools),
+            prompts_scanned=len(prompts),
+            resources_scanned=len(resources),
+            rules_checked=rules_checked,
+            rules_passed=rules_checked - rules_failed,
+            rules_failed=rules_failed,
+            total_findings=len(all_findings),
+            findings_by_severity=sev_counts,
+            findings_by_category=cat_counts,
+            findings=all_findings,
+        )

--- a/mcpscanner/core/analyzers/linter/finding.py
+++ b/mcpscanner/core/analyzers/linter/finding.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Data model for lint findings and severity levels."""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class LintSeverity(str, Enum):
+    """Severity levels for lint findings, ordered from most to least severe."""
+
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+    HINT = "hint"
+
+    @property
+    def rank(self) -> int:
+        return {
+            LintSeverity.ERROR: 0,
+            LintSeverity.WARNING: 1,
+            LintSeverity.INFO: 2,
+            LintSeverity.HINT: 3,
+        }[self]
+
+    def __lt__(self, other: "LintSeverity") -> bool:
+        return self.rank < other.rank
+
+
+@dataclass
+class LintFinding:
+    """A single finding produced by a lint rule."""
+
+    rule_id: str
+    severity: LintSeverity
+    category: str
+    message: str
+    recommendation: str
+    item_name: str = ""
+    location: Optional[str] = None
+    affected_items: int = 1
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            "rule_id": self.rule_id,
+            "severity": self.severity.value,
+            "category": self.category,
+            "message": self.message,
+            "recommendation": self.recommendation,
+            "item_name": self.item_name,
+            "affected_items": self.affected_items,
+        }
+        if self.location:
+            result["location"] = self.location
+        if self.details:
+            result["details"] = self.details
+        return result
+
+
+@dataclass
+class LintSummary:
+    """Aggregated lint results for a scan target."""
+
+    target: str
+    tools_scanned: int = 0
+    prompts_scanned: int = 0
+    resources_scanned: int = 0
+    rules_checked: int = 0
+    rules_passed: int = 0
+    rules_failed: int = 0
+    total_findings: int = 0
+    findings_by_severity: Dict[str, int] = field(default_factory=dict)
+    findings_by_category: Dict[str, int] = field(default_factory=dict)
+    findings: List[LintFinding] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "target": self.target,
+            "tools_scanned": self.tools_scanned,
+            "prompts_scanned": self.prompts_scanned,
+            "resources_scanned": self.resources_scanned,
+            "rules_checked": self.rules_checked,
+            "rules_passed": self.rules_passed,
+            "rules_failed": self.rules_failed,
+            "total_findings": self.total_findings,
+            "findings_by_severity": self.findings_by_severity,
+            "findings_by_category": self.findings_by_category,
+            "findings": [f.to_dict() for f in self.findings],
+        }

--- a/mcpscanner/core/analyzers/linter/formatter.py
+++ b/mcpscanner/core/analyzers/linter/formatter.py
@@ -1,0 +1,176 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Output formatters for the MCP schema linter."""
+
+from __future__ import annotations
+
+import json
+from typing import List
+
+from .finding import LintFinding, LintSeverity, LintSummary
+
+
+class LintFormatter:
+    """Format LintSummary for display."""
+
+    def __init__(self, summary: LintSummary) -> None:
+        self.summary = summary
+
+    def format_table(self) -> str:
+        """Produce the human-readable table output shown in CLI."""
+        lines: List[str] = []
+        s = self.summary
+
+        grouped = self._group_by_category(s.findings)
+
+        for category, findings in grouped:
+            lines.append(f"{category.title()} Quality")
+            header = (
+                f"    {'#':>3}  {'SEVERITY':<10}"
+                f"{'CODE':<37}"
+                f"{'FINDINGS':<40}"
+                f"{'RECOMMENDATION':<40}"
+                f"{'AFFECTED ITEMS':>14}"
+            )
+            lines.append(header)
+            lines.append("    " + "\u2014" * (len(header) - 4))
+
+            for idx, f in enumerate(findings, 1):
+                lines.append(
+                    f"    {idx:>3}  {f.severity.value:<10}"
+                    f"{f.rule_id:<37}"
+                    f"{_truncate(f.message, 38):<40}"
+                    f"{_truncate(f.recommendation, 38):<40}"
+                    f"{f.affected_items:>14}"
+                )
+
+        lines.append("")
+        lines.append(self._finding_counts_line(s))
+        lines.append(self._category_table(s))
+
+        lines.append("")
+        lines.append("=" * 60)
+        lines.append(self._summary_block(s))
+
+        return "\n".join(lines)
+
+    def format_summary(self) -> str:
+        """Produce a compact summary."""
+        s = self.summary
+        lines = [
+            "=" * 60,
+            self._summary_block(s),
+            "",
+            self._finding_counts_line(s),
+        ]
+        return "\n".join(lines)
+
+    def format_json(self) -> str:
+        """Produce deterministic JSON output for CI/CD pipelines."""
+        return json.dumps(self.summary.to_dict(), indent=2, sort_keys=False)
+
+    def format(self, fmt: str = "table") -> str:
+        if fmt == "json":
+            return self.format_json()
+        if fmt == "summary":
+            return self.format_summary()
+        return self.format_table()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _group_by_category(findings: List[LintFinding]) -> List[tuple]:
+        groups: dict[str, List[LintFinding]] = {}
+        for f in findings:
+            groups.setdefault(f.category, []).append(f)
+        order = ["tool", "prompt", "resource", "server"]
+        result = []
+        for cat in order:
+            if cat in groups:
+                result.append((cat, groups[cat]))
+        for cat in sorted(groups):
+            if cat not in order:
+                result.append((cat, groups[cat]))
+        return result
+
+    @staticmethod
+    def _finding_counts_line(s: LintSummary) -> str:
+        sev = s.findings_by_severity
+        parts = [
+            f"{sev.get('error', 0)} Error",
+            f"{sev.get('warning', 0)} Warning",
+            f"{sev.get('info', 0)} Info",
+            f"{sev.get('hint', 0)} Hint",
+        ]
+        return f"{s.total_findings} Findings ({', '.join(parts)})"
+
+    @staticmethod
+    def _category_table(s: LintSummary) -> str:
+        cats = s.findings_by_category
+        if not cats:
+            return ""
+        lines = [
+            f"  {'#':>3} | {'CATEGORY':<12} | {'ERROR':>5} | {'WARNING':>7} | {'INFO':>4} | {'HINT':>4}",
+            "  " + "-" * 55,
+        ]
+        for idx, (cat, _) in enumerate(sorted(cats.items()), 1):
+            cat_findings = [f for f in s.findings if f.category == cat]
+            by_sev = {}
+            for f in cat_findings:
+                by_sev[f.severity.value] = by_sev.get(f.severity.value, 0) + 1
+            lines.append(
+                f"  {idx:>3} | {cat.title():<12} "
+                f"| {by_sev.get('error', 0):>5} "
+                f"| {by_sev.get('warning', 0):>7} "
+                f"| {by_sev.get('info', 0):>4} "
+                f"| {by_sev.get('hint', 0):>4}"
+            )
+        return "\n".join(lines)
+
+    @staticmethod
+    def _summary_block(s: LintSummary) -> str:
+        total_scanned = s.tools_scanned + s.prompts_scanned + s.resources_scanned
+        parts = []
+        if s.tools_scanned:
+            parts.append(f"{s.tools_scanned} tools")
+        if s.prompts_scanned:
+            parts.append(f"{s.prompts_scanned} prompts")
+        if s.resources_scanned:
+            parts.append(f"{s.resources_scanned} resources")
+        scanned_str = ", ".join(parts) if parts else "0 items"
+
+        pct = (
+            f"{s.rules_passed / s.rules_checked * 100:.0f}%"
+            if s.rules_checked
+            else "N/A"
+        )
+        lines = [
+            "Summary",
+            f"  Scanned:       {scanned_str}",
+            f"  Rules checked: {s.rules_checked}",
+            f"  Rules passed:  {s.rules_passed} ({pct})",
+            f"  Rules failed:  {s.rules_failed}",
+            f"  Total issues:  {s.total_findings}",
+        ]
+        return "\n".join(lines)
+
+
+def _truncate(text: str, max_len: int) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3] + "..."

--- a/mcpscanner/core/analyzers/linter/rule.py
+++ b/mcpscanner/core/analyzers/linter/rule.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Lint rule base class and registry."""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Set
+
+from .finding import LintFinding, LintSeverity
+
+logger = logging.getLogger(__name__)
+
+
+class LintRule(ABC):
+    """Base class for all lint rules."""
+
+    id: str
+    severity: LintSeverity
+    category: str  # "tool", "prompt", "resource", "server"
+    description: str
+
+    def __init__(
+        self,
+        rule_id: str,
+        severity: LintSeverity,
+        category: str,
+        description: str,
+    ):
+        self.id = rule_id
+        self.severity = severity
+        self.category = category
+        self.description = description
+
+    @abstractmethod
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        """Run this rule against a single item and return findings."""
+
+    def _finding(
+        self,
+        message: str,
+        recommendation: str,
+        item_name: str = "",
+        location: Optional[str] = None,
+        affected_items: int = 1,
+        **extra: Any,
+    ) -> LintFinding:
+        """Convenience helper to build a LintFinding from this rule."""
+        return LintFinding(
+            rule_id=self.id,
+            severity=self.severity,
+            category=self.category,
+            message=message,
+            recommendation=recommendation,
+            item_name=item_name,
+            location=location,
+            affected_items=affected_items,
+            details=extra if extra else {},
+        )
+
+
+class RuleRegistry:
+    """Collects lint rules and supports filtering by ID, category, or severity."""
+
+    def __init__(self) -> None:
+        self._rules: Dict[str, LintRule] = {}
+        self._disabled: Set[str] = set()
+        self._severity_overrides: Dict[str, LintSeverity] = {}
+
+    def register(self, rule: LintRule) -> None:
+        self._rules[rule.id] = rule
+
+    def register_all(self, rules: List[LintRule]) -> None:
+        for rule in rules:
+            self.register(rule)
+
+    def disable(self, rule_id: str) -> None:
+        self._disabled.add(rule_id)
+
+    def enable(self, rule_id: str) -> None:
+        self._disabled.discard(rule_id)
+
+    def set_severity(self, rule_id: str, severity: LintSeverity) -> None:
+        self._severity_overrides[rule_id] = severity
+
+    def get_active_rules(
+        self,
+        category: Optional[str] = None,
+    ) -> List[LintRule]:
+        """Return enabled rules, optionally filtered by category.
+
+        Severity overrides are applied on copies so that the canonical
+        rule objects remain unchanged across calls.
+        """
+        import copy
+
+        rules: List[LintRule] = []
+        for rule_id, rule in self._rules.items():
+            if rule_id in self._disabled:
+                continue
+            if category and rule.category != category:
+                continue
+            if rule_id in self._severity_overrides:
+                rule = copy.copy(rule)
+                rule.severity = self._severity_overrides[rule_id]
+            rules.append(rule)
+        return rules
+
+    def get_rule(self, rule_id: str) -> Optional[LintRule]:
+        return self._rules.get(rule_id)
+
+    @property
+    def all_rule_ids(self) -> List[str]:
+        return list(self._rules.keys())
+
+    @property
+    def total_rules(self) -> int:
+        return len(self._rules)
+
+    @property
+    def active_count(self) -> int:
+        return len(self._rules) - len(self._disabled)

--- a/mcpscanner/core/analyzers/linter/rules/__init__.py
+++ b/mcpscanner/core/analyzers/linter/rules/__init__.py
@@ -1,0 +1,31 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Built-in lint rules for MCP schemas."""
+
+from .prompt_rules import PROMPT_RULES
+from .resource_rules import RESOURCE_RULES
+from .server_rules import SERVER_RULES
+from .tool_rules import TOOL_RULES
+
+ALL_RULES = TOOL_RULES + PROMPT_RULES + RESOURCE_RULES + SERVER_RULES
+
+__all__ = [
+    "ALL_RULES",
+    "TOOL_RULES",
+    "PROMPT_RULES",
+    "RESOURCE_RULES",
+    "SERVER_RULES",
+]

--- a/mcpscanner/core/analyzers/linter/rules/prompt_rules.py
+++ b/mcpscanner/core/analyzers/linter/rules/prompt_rules.py
@@ -1,0 +1,184 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Built-in lint rules for MCP prompt schemas (8 rules)."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List
+
+from ..finding import LintFinding, LintSeverity
+from ..rule import LintRule
+
+_SNAKE_CASE = re.compile(r"^[a-z][a-z0-9]*(_[a-z0-9]+)*$")
+_CAMEL_CASE = re.compile(r"^[a-z][a-zA-Z0-9]*$")
+_KEBAB_CASE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
+_MIN_DESC_LEN = 20
+
+
+class PromptHasName(LintRule):
+    def __init__(self) -> None:
+        super().__init__("prompt-has-name", LintSeverity.ERROR, "prompt", "Prompt must have a non-empty name")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = (item.get("name") or "").strip()
+        if not name:
+            return [self._finding("Prompt is missing a name", "Add a 'name' field to the prompt definition")]
+        return []
+
+
+class PromptHasDescription(LintRule):
+    def __init__(self) -> None:
+        super().__init__("prompt-has-description", LintSeverity.WARNING, "prompt", "Prompt must have a description")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        desc = (item.get("description") or "").strip()
+        if not desc:
+            return [self._finding(
+                f"Prompt '{name}' has no description",
+                "Add a 'description' that explains what this prompt does",
+                item_name=name,
+            )]
+        return []
+
+
+class PromptDescriptionMinLength(LintRule):
+    def __init__(self) -> None:
+        super().__init__("prompt-description-min-length", LintSeverity.INFO, "prompt", f"Description should be at least {_MIN_DESC_LEN} characters")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        desc = (item.get("description") or "").strip()
+        if desc and len(desc) < _MIN_DESC_LEN:
+            return [self._finding(
+                f"Prompt '{name}' description is only {len(desc)} characters",
+                f"Expand the description to at least {_MIN_DESC_LEN} characters",
+                item_name=name,
+            )]
+        return []
+
+
+class PromptNameConvention(LintRule):
+    def __init__(self) -> None:
+        super().__init__("prompt-name-convention", LintSeverity.INFO, "prompt", "Name should follow a consistent convention")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = (item.get("name") or "").strip()
+        if not name:
+            return []
+        if _SNAKE_CASE.match(name) or _CAMEL_CASE.match(name) or _KEBAB_CASE.match(name):
+            return []
+        return [self._finding(
+            f"Prompt name '{name}' does not follow a standard convention",
+            "Use snake_case, camelCase, or kebab-case for prompt names",
+            item_name=name,
+        )]
+
+
+class PromptHasArguments(LintRule):
+    def __init__(self) -> None:
+        super().__init__("prompt-has-arguments", LintSeverity.INFO, "prompt", "Prompt should define arguments")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        args = item.get("arguments")
+        if args is None:
+            return [self._finding(
+                f"Prompt '{name}' does not define any arguments",
+                "Add an 'arguments' list to describe expected inputs (even if empty)",
+                item_name=name,
+            )]
+        return []
+
+
+class PromptArgumentHasDescription(LintRule):
+    def __init__(self) -> None:
+        super().__init__("prompt-argument-has-description", LintSeverity.INFO, "prompt", "Each argument should have a description")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        args = item.get("arguments", [])
+        if not isinstance(args, list):
+            return []
+        undescribed = [a.get("name", "?") for a in args if isinstance(a, dict) and not a.get("description")]
+        if undescribed:
+            return [self._finding(
+                f"Prompt '{name}' arguments missing descriptions: {', '.join(undescribed)}",
+                "Add a 'description' to each argument",
+                item_name=name,
+                affected_items=len(undescribed),
+            )]
+        return []
+
+
+class PromptArgumentHasRequired(LintRule):
+    def __init__(self) -> None:
+        super().__init__("prompt-argument-has-required", LintSeverity.INFO, "prompt", "Arguments should specify required flag")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        args = item.get("arguments", [])
+        if not isinstance(args, list):
+            return []
+        missing_req = [a.get("name", "?") for a in args if isinstance(a, dict) and "required" not in a]
+        if missing_req:
+            return [self._finding(
+                f"Prompt '{name}' arguments missing 'required' flag: {', '.join(missing_req)}",
+                "Set 'required: true' or 'required: false' on each argument",
+                item_name=name,
+                affected_items=len(missing_req),
+            )]
+        return []
+
+
+class PromptNoDuplicateArguments(LintRule):
+    def __init__(self) -> None:
+        super().__init__("prompt-no-duplicate-arguments", LintSeverity.ERROR, "prompt", "No duplicate argument names")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        args = item.get("arguments", [])
+        if not isinstance(args, list):
+            return []
+        seen: set[str] = set()
+        dupes: List[str] = []
+        for a in args:
+            if isinstance(a, dict):
+                arg_name = a.get("name", "")
+                if arg_name in seen:
+                    dupes.append(arg_name)
+                seen.add(arg_name)
+        if dupes:
+            return [self._finding(
+                f"Prompt '{name}' has duplicate argument names: {', '.join(dupes)}",
+                "Use unique names for each argument",
+                item_name=name,
+                affected_items=len(dupes),
+            )]
+        return []
+
+
+PROMPT_RULES: List[LintRule] = [
+    PromptHasName(),
+    PromptHasDescription(),
+    PromptDescriptionMinLength(),
+    PromptNameConvention(),
+    PromptHasArguments(),
+    PromptArgumentHasDescription(),
+    PromptArgumentHasRequired(),
+    PromptNoDuplicateArguments(),
+]

--- a/mcpscanner/core/analyzers/linter/rules/resource_rules.py
+++ b/mcpscanner/core/analyzers/linter/rules/resource_rules.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Built-in lint rules for MCP resource schemas (6 rules)."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List
+from urllib.parse import urlparse
+
+from ..finding import LintFinding, LintSeverity
+from ..rule import LintRule
+
+_SNAKE_CASE = re.compile(r"^[a-z][a-z0-9]*(_[a-z0-9]+)*$")
+_CAMEL_CASE = re.compile(r"^[a-z][a-zA-Z0-9]*$")
+_KEBAB_CASE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
+_MIME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9!#$&\-^_.+]*\/[a-zA-Z0-9][a-zA-Z0-9!#$&\-^_.+]*$")
+
+
+class ResourceHasName(LintRule):
+    def __init__(self) -> None:
+        super().__init__("resource-has-name", LintSeverity.ERROR, "resource", "Resource must have a non-empty name")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = (item.get("name") or "").strip()
+        if not name:
+            uri = item.get("uri", "")
+            return [self._finding(
+                f"Resource '{uri}' is missing a name",
+                "Add a 'name' field to the resource definition",
+                item_name=uri,
+            )]
+        return []
+
+
+class ResourceHasDescription(LintRule):
+    def __init__(self) -> None:
+        super().__init__("resource-has-description", LintSeverity.WARNING, "resource", "Resource should have a description")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", item.get("uri", ""))
+        desc = (item.get("description") or "").strip()
+        if not desc:
+            return [self._finding(
+                f"Resource '{name}' has no description",
+                "Add a 'description' that explains what this resource provides",
+                item_name=name,
+            )]
+        return []
+
+
+class ResourceHasMimeType(LintRule):
+    def __init__(self) -> None:
+        super().__init__("resource-has-mime-type", LintSeverity.WARNING, "resource", "Resource should specify a MIME type")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", item.get("uri", ""))
+        if not item.get("mimeType"):
+            return [self._finding(
+                f"Resource '{name}' has no MIME type specified",
+                "Add a 'mimeType' field (e.g. 'application/json', 'text/plain')",
+                item_name=name,
+            )]
+        return []
+
+
+class ResourceMimeTypeValid(LintRule):
+    def __init__(self) -> None:
+        super().__init__("resource-mime-type-valid", LintSeverity.WARNING, "resource", "MIME type should be valid format")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", item.get("uri", ""))
+        mime = item.get("mimeType", "")
+        if mime and not _MIME_PATTERN.match(mime):
+            return [self._finding(
+                f"Resource '{name}' has invalid MIME type '{mime}'",
+                "Use a valid MIME type format (e.g. 'application/json')",
+                item_name=name,
+            )]
+        return []
+
+
+class ResourceUriValid(LintRule):
+    def __init__(self) -> None:
+        super().__init__("resource-uri-valid", LintSeverity.INFO, "resource", "URI should be well-formed")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        uri = (item.get("uri") or "").strip()
+        if not uri:
+            return [self._finding(
+                f"Resource '{name}' has no URI",
+                "Add a 'uri' field to identify this resource",
+                item_name=name,
+            )]
+        parsed = urlparse(uri)
+        if not parsed.scheme:
+            return [self._finding(
+                f"Resource '{name}' URI '{uri}' has no scheme",
+                "Use a fully-qualified URI with a scheme (e.g. 'file://', 'https://')",
+                item_name=name,
+            )]
+        return []
+
+
+class ResourceNameConvention(LintRule):
+    def __init__(self) -> None:
+        super().__init__("resource-name-convention", LintSeverity.INFO, "resource", "Name should follow a consistent convention")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = (item.get("name") or "").strip()
+        if not name:
+            return []
+        # Resources have broader naming: allow snake, camel, kebab, or phrases with spaces
+        if _SNAKE_CASE.match(name) or _CAMEL_CASE.match(name) or _KEBAB_CASE.match(name):
+            return []
+        if " " in name and name == name.strip() and "  " not in name:
+            return []
+        return [self._finding(
+            f"Resource name '{name}' uses inconsistent naming",
+            "Use a consistent convention: snake_case, camelCase, kebab-case, or readable phrases",
+            item_name=name,
+        )]
+
+
+RESOURCE_RULES: List[LintRule] = [
+    ResourceHasName(),
+    ResourceHasDescription(),
+    ResourceHasMimeType(),
+    ResourceMimeTypeValid(),
+    ResourceUriValid(),
+    ResourceNameConvention(),
+]

--- a/mcpscanner/core/analyzers/linter/rules/server_rules.py
+++ b/mcpscanner/core/analyzers/linter/rules/server_rules.py
@@ -1,0 +1,125 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Built-in lint rules for MCP server-level validation (5 rules)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..finding import LintFinding, LintSeverity
+from ..rule import LintRule
+
+_MAX_TOOLS = 100
+
+
+class ServerHasCapabilities(LintRule):
+    def __init__(self) -> None:
+        super().__init__("server-has-capabilities", LintSeverity.WARNING, "server", "Server should expose tools, prompts, or resources")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        tools = item.get("tools", [])
+        prompts = item.get("prompts", [])
+        resources = item.get("resources", [])
+        if not tools and not prompts and not resources:
+            return [self._finding(
+                "Server does not expose any tools, prompts, or resources",
+                "Register at least one tool, prompt, or resource",
+            )]
+        return []
+
+
+class ServerToolNamesUnique(LintRule):
+    def __init__(self) -> None:
+        super().__init__("server-tool-names-unique", LintSeverity.ERROR, "server", "All tool names must be unique")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        tools = item.get("tools", [])
+        names: Dict[str, int] = {}
+        for t in tools:
+            n = t.get("name", "")
+            names[n] = names.get(n, 0) + 1
+        dupes = [n for n, c in names.items() if c > 1 and n]
+        if dupes:
+            return [self._finding(
+                f"Duplicate tool names: {', '.join(dupes)}",
+                "Ensure every tool has a unique name",
+                affected_items=len(dupes),
+            )]
+        return []
+
+
+class ServerPromptNamesUnique(LintRule):
+    def __init__(self) -> None:
+        super().__init__("server-prompt-names-unique", LintSeverity.ERROR, "server", "All prompt names must be unique")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        prompts = item.get("prompts", [])
+        names: Dict[str, int] = {}
+        for p in prompts:
+            n = p.get("name", "")
+            names[n] = names.get(n, 0) + 1
+        dupes = [n for n, c in names.items() if c > 1 and n]
+        if dupes:
+            return [self._finding(
+                f"Duplicate prompt names: {', '.join(dupes)}",
+                "Ensure every prompt has a unique name",
+                affected_items=len(dupes),
+            )]
+        return []
+
+
+class ServerResourceUrisUnique(LintRule):
+    def __init__(self) -> None:
+        super().__init__("server-resource-uris-unique", LintSeverity.ERROR, "server", "All resource URIs must be unique")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        resources = item.get("resources", [])
+        uris: Dict[str, int] = {}
+        for r in resources:
+            u = r.get("uri", "")
+            uris[u] = uris.get(u, 0) + 1
+        dupes = [u for u, c in uris.items() if c > 1 and u]
+        if dupes:
+            return [self._finding(
+                f"Duplicate resource URIs: {', '.join(dupes)}",
+                "Ensure every resource has a unique URI",
+                affected_items=len(dupes),
+            )]
+        return []
+
+
+class ServerNoExcessiveTools(LintRule):
+    def __init__(self) -> None:
+        super().__init__("server-no-excessive-tools", LintSeverity.INFO, "server", f"Server should not expose more than {_MAX_TOOLS} tools")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        tools = item.get("tools", [])
+        if len(tools) > _MAX_TOOLS:
+            return [self._finding(
+                f"Server exposes {len(tools)} tools (recommended max {_MAX_TOOLS})",
+                "Consider splitting into multiple focused servers or using tool namespacing",
+                affected_items=len(tools),
+            )]
+        return []
+
+
+SERVER_RULES: List[LintRule] = [
+    ServerHasCapabilities(),
+    ServerPromptNamesUnique(),
+    ServerResourceUrisUnique(),
+    ServerToolNamesUnique(),
+    ServerNoExcessiveTools(),
+]

--- a/mcpscanner/core/analyzers/linter/rules/tool_rules.py
+++ b/mcpscanner/core/analyzers/linter/rules/tool_rules.py
@@ -1,0 +1,416 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Built-in lint rules for MCP tool schemas (18 rules)."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List
+
+from ..finding import LintFinding, LintSeverity
+from ..rule import LintRule
+
+_SNAKE_CASE = re.compile(r"^[a-z][a-z0-9]*(_[a-z0-9]+)*$")
+_CAMEL_CASE = re.compile(r"^[a-z][a-zA-Z0-9]*$")
+_HTML_TAG = re.compile(r"<\s*/?\s*[a-zA-Z][^>]*>")
+_MAX_NAME_LEN = 64
+_MIN_DESC_LEN = 20
+_MAX_SCHEMA_DEPTH = 5
+
+
+class ToolHasName(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-has-name", LintSeverity.ERROR, "tool", "Tool must have a non-empty name")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = (item.get("name") or "").strip()
+        if not name:
+            return [self._finding("Tool is missing a name", "Add a 'name' field to the tool definition")]
+        return []
+
+
+class ToolHasDescription(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-has-description", LintSeverity.WARNING, "tool", "Tool must have a description")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        desc = (item.get("description") or "").strip()
+        if not desc:
+            return [self._finding(f"Tool '{name}' has no description", "Add a 'description' that explains what this tool does", item_name=name)]
+        return []
+
+
+class ToolDescriptionMinLength(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-description-min-length", LintSeverity.INFO, "tool", f"Description should be at least {_MIN_DESC_LEN} characters")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        desc = (item.get("description") or "").strip()
+        if desc and len(desc) < _MIN_DESC_LEN:
+            return [self._finding(
+                f"Tool '{name}' description is only {len(desc)} characters",
+                f"Expand the description to at least {_MIN_DESC_LEN} characters for clarity",
+                item_name=name,
+            )]
+        return []
+
+
+class ToolDescriptionNotName(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-description-not-name", LintSeverity.WARNING, "tool", "Description should not just repeat the name")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = (item.get("name") or "").strip()
+        desc = (item.get("description") or "").strip()
+        if name and desc and desc.lower().replace("_", " ") == name.lower().replace("_", " "):
+            return [self._finding(
+                f"Tool '{name}' description just repeats the tool name",
+                "Write a meaningful description that explains the tool's purpose",
+                item_name=name,
+            )]
+        return []
+
+
+class ToolNameConvention(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-name-convention", LintSeverity.INFO, "tool", "Name should follow snake_case or camelCase")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = (item.get("name") or "").strip()
+        if not name:
+            return []
+        if _SNAKE_CASE.match(name) or _CAMEL_CASE.match(name):
+            return []
+        return [self._finding(
+            f"Tool name '{name}' does not follow snake_case or camelCase",
+            "Rename to snake_case (e.g. 'my_tool') or camelCase (e.g. 'myTool')",
+            item_name=name,
+        )]
+
+
+class ToolNameMaxLength(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-name-max-length", LintSeverity.INFO, "tool", f"Name should be under {_MAX_NAME_LEN} characters")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = (item.get("name") or "").strip()
+        if name and len(name) > _MAX_NAME_LEN:
+            return [self._finding(
+                f"Tool name '{name}' is {len(name)} characters (max {_MAX_NAME_LEN})",
+                f"Shorten the tool name to under {_MAX_NAME_LEN} characters",
+                item_name=name,
+            )]
+        return []
+
+
+class ToolHasInputSchema(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-has-input-schema", LintSeverity.WARNING, "tool", "Tool should define an inputSchema")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        if "inputSchema" not in item:
+            return [self._finding(
+                f"Tool '{name}' has no inputSchema defined",
+                "Add an 'inputSchema' to define the expected parameters",
+                item_name=name,
+            )]
+        return []
+
+
+class ToolInputSchemaHasProperties(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-input-schema-has-properties", LintSeverity.WARNING, "tool", "inputSchema should define properties")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        schema = item.get("inputSchema", {})
+        if not isinstance(schema, dict):
+            return []
+        if schema and "properties" not in schema:
+            return [self._finding(
+                f"Tool '{name}' inputSchema has no 'properties' defined",
+                "Add a 'properties' object to describe each parameter",
+                item_name=name,
+                location="inputSchema",
+            )]
+        return []
+
+
+class ToolInputSchemaHasRequired(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-input-schema-has-required", LintSeverity.INFO, "tool", "inputSchema should declare required fields")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        schema = item.get("inputSchema", {})
+        if not isinstance(schema, dict):
+            return []
+        props = schema.get("properties", {})
+        if props and "required" not in schema:
+            return [self._finding(
+                f"Tool '{name}' inputSchema has properties but no 'required' list",
+                "Add a 'required' array listing mandatory parameters",
+                item_name=name,
+                location="inputSchema",
+            )]
+        return []
+
+
+class ToolRequiredParamsDefined(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-required-params-defined", LintSeverity.ERROR, "tool", "Required params must exist in properties")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        schema = item.get("inputSchema", {})
+        if not isinstance(schema, dict):
+            return []
+        props = schema.get("properties", {})
+        required = schema.get("required", [])
+        if not isinstance(required, list) or not isinstance(props, dict):
+            return []
+        missing = [r for r in required if r not in props]
+        if missing:
+            return [self._finding(
+                f"Tool '{name}' requires undefined parameters: {', '.join(missing)}",
+                "Either add the missing properties or remove them from 'required'",
+                item_name=name,
+                location="inputSchema.required",
+                affected_items=len(missing),
+            )]
+        return []
+
+
+class ToolSchemaPropertiesHaveTypes(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-schema-properties-have-types", LintSeverity.WARNING, "tool", "Each property should have a type")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        schema = item.get("inputSchema", {})
+        if not isinstance(schema, dict):
+            return []
+        props = schema.get("properties", {})
+        if not isinstance(props, dict):
+            return []
+        untyped = [k for k, v in props.items() if isinstance(v, dict) and "type" not in v]
+        if untyped:
+            return [self._finding(
+                f"Tool '{name}' properties missing 'type': {', '.join(untyped)}",
+                "Add a 'type' field (e.g. 'string', 'integer') to each property",
+                item_name=name,
+                location="inputSchema.properties",
+                affected_items=len(untyped),
+            )]
+        return []
+
+
+class ToolSchemaPropertiesHaveDescriptions(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-schema-properties-have-descriptions", LintSeverity.INFO, "tool", "Each property should have a description")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        schema = item.get("inputSchema", {})
+        if not isinstance(schema, dict):
+            return []
+        props = schema.get("properties", {})
+        if not isinstance(props, dict):
+            return []
+        undescribed = [k for k, v in props.items() if isinstance(v, dict) and not v.get("description")]
+        if undescribed:
+            return [self._finding(
+                f"Tool '{name}' properties missing descriptions: {', '.join(undescribed)}",
+                "Add a 'description' to each property for better documentation",
+                item_name=name,
+                location="inputSchema.properties",
+                affected_items=len(undescribed),
+            )]
+        return []
+
+
+class ToolSchemaHasExamples(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-schema-has-examples", LintSeverity.INFO, "tool", "Properties should include examples")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        schema = item.get("inputSchema", {})
+        if not isinstance(schema, dict):
+            return []
+        props = schema.get("properties", {})
+        if not isinstance(props, dict):
+            return []
+        no_example = [
+            k for k, v in props.items()
+            if isinstance(v, dict) and "example" not in v and "examples" not in v and "default" not in v
+        ]
+        if no_example:
+            return [self._finding(
+                f"Tool '{name}' properties missing examples: {', '.join(no_example)}",
+                "Add 'example' field to properties for better documentation",
+                item_name=name,
+                location="inputSchema.properties",
+                affected_items=len(no_example),
+            )]
+        return []
+
+
+class ToolOutputSchemaDefined(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-output-schema-defined", LintSeverity.INFO, "tool", "Tool should define an outputSchema")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        if "outputSchema" not in item:
+            return [self._finding(
+                f"Tool '{name}' has no outputSchema defined",
+                "Add an outputSchema to define the structure of tool results",
+                item_name=name,
+            )]
+        return []
+
+
+class ToolNoEmptyEnum(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-no-empty-enum", LintSeverity.WARNING, "tool", "Enum properties must have values")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        schema = item.get("inputSchema", {})
+        if not isinstance(schema, dict):
+            return []
+        props = schema.get("properties", {})
+        if not isinstance(props, dict):
+            return []
+        empty_enums = [k for k, v in props.items() if isinstance(v, dict) and "enum" in v and not v["enum"]]
+        if empty_enums:
+            return [self._finding(
+                f"Tool '{name}' has empty enum for: {', '.join(empty_enums)}",
+                "Provide at least one value in the 'enum' array",
+                item_name=name,
+                location="inputSchema.properties",
+                affected_items=len(empty_enums),
+            )]
+        return []
+
+
+def _schema_depth(schema: Any, current: int = 0) -> int:
+    if not isinstance(schema, dict):
+        return current
+    deepest = current
+    for key in ("properties", "items", "additionalProperties"):
+        child = schema.get(key)
+        if isinstance(child, dict):
+            if key == "properties":
+                for v in child.values():
+                    deepest = max(deepest, _schema_depth(v, current + 1))
+            else:
+                deepest = max(deepest, _schema_depth(child, current + 1))
+    return deepest
+
+
+class ToolSchemaMaxDepth(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-schema-max-depth", LintSeverity.WARNING, "tool", f"Schema nesting should not exceed depth {_MAX_SCHEMA_DEPTH}")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        schema = item.get("inputSchema", {})
+        if not isinstance(schema, dict):
+            return []
+        depth = _schema_depth(schema)
+        if depth > _MAX_SCHEMA_DEPTH:
+            return [self._finding(
+                f"Tool '{name}' inputSchema nesting depth is {depth} (max {_MAX_SCHEMA_DEPTH})",
+                "Flatten the schema structure to reduce complexity",
+                item_name=name,
+                location="inputSchema",
+            )]
+        return []
+
+
+class ToolNoDuplicateParams(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-no-duplicate-params", LintSeverity.ERROR, "tool", "No duplicate property names in schema")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        # JSON object keys are unique by spec; this checks for case-insensitive collisions
+        name = item.get("name", "")
+        schema = item.get("inputSchema", {})
+        if not isinstance(schema, dict):
+            return []
+        props = schema.get("properties", {})
+        if not isinstance(props, dict):
+            return []
+        seen: Dict[str, str] = {}
+        dupes: List[str] = []
+        for k in props:
+            lower = k.lower()
+            if lower in seen:
+                dupes.append(f"'{k}' vs '{seen[lower]}'")
+            else:
+                seen[lower] = k
+        if dupes:
+            return [self._finding(
+                f"Tool '{name}' has case-insensitive duplicate parameters: {', '.join(dupes)}",
+                "Use distinct parameter names to avoid confusion",
+                item_name=name,
+                location="inputSchema.properties",
+                affected_items=len(dupes),
+            )]
+        return []
+
+
+class ToolDescriptionNoHtml(LintRule):
+    def __init__(self) -> None:
+        super().__init__("tool-description-no-html", LintSeverity.INFO, "tool", "Description should not contain HTML tags")
+
+    def check(self, item: Dict[str, Any], context: Dict[str, Any]) -> List[LintFinding]:
+        name = item.get("name", "")
+        desc = item.get("description") or ""
+        if _HTML_TAG.search(desc):
+            return [self._finding(
+                f"Tool '{name}' description contains HTML tags",
+                "Use plain text in descriptions; HTML will not render in most MCP clients",
+                item_name=name,
+            )]
+        return []
+
+
+TOOL_RULES: List[LintRule] = [
+    ToolHasName(),
+    ToolHasDescription(),
+    ToolDescriptionMinLength(),
+    ToolDescriptionNotName(),
+    ToolNameConvention(),
+    ToolNameMaxLength(),
+    ToolHasInputSchema(),
+    ToolInputSchemaHasProperties(),
+    ToolInputSchemaHasRequired(),
+    ToolRequiredParamsDefined(),
+    ToolSchemaPropertiesHaveTypes(),
+    ToolSchemaPropertiesHaveDescriptions(),
+    ToolSchemaHasExamples(),
+    ToolOutputSchemaDefined(),
+    ToolNoEmptyEnum(),
+    ToolSchemaMaxDepth(),
+    ToolNoDuplicateParams(),
+    ToolDescriptionNoHtml(),
+]

--- a/mcpscanner/core/analyzers/linter/rulesets.py
+++ b/mcpscanner/core/analyzers/linter/rulesets.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Predefined rulesets for the MCP schema linter."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from .finding import LintSeverity
+from .rule import RuleRegistry
+from .rules import ALL_RULES
+
+QUALITY_RULE_IDS = frozenset({
+    "tool-has-description",
+    "tool-description-min-length",
+    "tool-description-not-name",
+    "tool-schema-properties-have-descriptions",
+    "tool-schema-has-examples",
+    "tool-output-schema-defined",
+    "tool-description-no-html",
+    "prompt-has-description",
+    "prompt-description-min-length",
+    "prompt-argument-has-description",
+    "resource-has-description",
+})
+
+
+def build_registry(
+    ruleset: str = "recommended",
+    overrides: Optional[Dict[str, str]] = None,
+) -> RuleRegistry:
+    """Build a RuleRegistry for a named ruleset with optional per-rule overrides.
+
+    Rulesets:
+      - ``recommended``: all rules at default severities
+      - ``strict``: all rules; ``info`` promoted to ``warning``
+      - ``quality``: only documentation/completeness rules
+    """
+    registry = RuleRegistry()
+    registry.register_all(ALL_RULES)
+
+    if ruleset == "quality":
+        for rule_id in registry.all_rule_ids:
+            if rule_id not in QUALITY_RULE_IDS:
+                registry.disable(rule_id)
+    elif ruleset == "strict":
+        for rule_id in registry.all_rule_ids:
+            rule = registry.get_rule(rule_id)
+            if rule and rule.severity == LintSeverity.INFO:
+                registry.set_severity(rule_id, LintSeverity.WARNING)
+
+    if overrides:
+        for rule_id, action in overrides.items():
+            if action == "off":
+                registry.disable(rule_id)
+            else:
+                try:
+                    registry.set_severity(rule_id, LintSeverity(action))
+                except ValueError:
+                    pass
+
+    return registry

--- a/mcpscanner/core/models.py
+++ b/mcpscanner/core/models.py
@@ -61,6 +61,7 @@ class AnalyzerEnum(str, Enum):
     VIRUSTOTAL = "virustotal"
     READINESS = "readiness"
     PROMPT_DEFENSE = "prompt_defense"
+    LINT = "lint"
 
 
 class AnalysisContext(BaseModel):

--- a/tests/linter/__init__.py
+++ b/tests/linter/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/linter/fixtures/bad_tools.json
+++ b/tests/linter/fixtures/bad_tools.json
@@ -1,0 +1,24 @@
+{
+  "tools": [
+    {
+      "name": "",
+      "description": ""
+    },
+    {
+      "name": "A Very Long And Poorly Named Tool That Violates All Naming Conventions And Exceeds The Maximum Length",
+      "description": "A Very Long And Poorly Named Tool That Violates All Naming Conventions And Exceeds The Maximum Length",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "Param": { "enum": [] },
+          "param": { "type": "string" }
+        },
+        "required": ["missing_param"]
+      }
+    },
+    {
+      "name": "html_desc",
+      "description": "<p>This has <b>HTML</b> in it</p>"
+    }
+  ]
+}

--- a/tests/linter/fixtures/good_tools.json
+++ b/tests/linter/fixtures/good_tools.json
@@ -1,0 +1,56 @@
+{
+  "tools": [
+    {
+      "name": "read_wiki_structure",
+      "description": "Read the hierarchical page structure of a wiki including section headings and nesting levels.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repoName": {
+            "type": "string",
+            "description": "The repository name to read the wiki from",
+            "example": "facebook/react"
+          },
+          "page": {
+            "type": "string",
+            "description": "Optional page path within the wiki",
+            "default": "index"
+          }
+        },
+        "required": ["repoName"]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "sections": { "type": "array" }
+        }
+      }
+    },
+    {
+      "name": "search_content",
+      "description": "Search across all wiki pages for matching content using full-text search capabilities.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "The search query string",
+            "example": "authentication flow"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of results to return",
+            "default": 10
+          }
+        },
+        "required": ["query"]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "results": { "type": "array" }
+        }
+      }
+    }
+  ]
+}

--- a/tests/linter/test_cli_integration.py
+++ b/tests/linter/test_cli_integration.py
@@ -1,0 +1,128 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""CLI integration tests for the lint subcommand (static file mode)."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from mcpscanner.core.analyzers.linter.engine import LintEngine
+from mcpscanner.core.analyzers.linter.formatter import LintFormatter
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class TestStaticFileLinting:
+    def test_lint_good_tools_file(self):
+        data = json.loads((FIXTURES / "good_tools.json").read_text())
+        tools = data["tools"]
+        engine = LintEngine()
+        summary = engine.lint(tools=tools, target="good_tools.json")
+        tool_findings = [f for f in summary.findings if f.category == "tool"]
+        error_findings = [f for f in tool_findings if f.severity.value == "error"]
+        assert len(error_findings) == 0
+
+    def test_lint_bad_tools_file(self):
+        data = json.loads((FIXTURES / "bad_tools.json").read_text())
+        tools = data["tools"]
+        engine = LintEngine()
+        summary = engine.lint(tools=tools, target="bad_tools.json")
+        rule_ids = {f.rule_id for f in summary.findings}
+        assert "tool-has-name" in rule_ids
+        assert "tool-required-params-defined" in rule_ids
+
+    def test_lint_produces_json_output(self):
+        data = json.loads((FIXTURES / "bad_tools.json").read_text())
+        tools = data["tools"]
+        engine = LintEngine()
+        summary = engine.lint(tools=tools, target="test")
+        fmt = LintFormatter(summary)
+        output = json.loads(fmt.format_json())
+        assert output["total_findings"] > 0
+        assert len(output["findings"]) > 0
+
+    def test_lint_produces_table_output(self):
+        data = json.loads((FIXTURES / "bad_tools.json").read_text())
+        tools = data["tools"]
+        engine = LintEngine()
+        summary = engine.lint(tools=tools, target="test")
+        fmt = LintFormatter(summary)
+        output = fmt.format_table()
+        assert "tool-has-name" in output
+        assert "Quality" in output
+
+    def test_strict_ruleset_catches_more(self):
+        data = json.loads((FIXTURES / "good_tools.json").read_text())
+        tools = data["tools"]
+        rec = LintEngine(ruleset="recommended")
+        strict = LintEngine(ruleset="strict")
+        rec_summary = rec.lint(tools=tools, target="test")
+        strict_summary = strict.lint(tools=tools, target="test")
+        # Strict should catch at least as many issues
+        assert strict_summary.total_findings >= rec_summary.total_findings
+
+    def test_quality_ruleset_filters_rules(self):
+        engine = LintEngine(ruleset="quality")
+        tool = {"name": "t"}
+        summary = engine.lint(tools=[tool], target="test")
+        for f in summary.findings:
+            if f.category == "tool":
+                assert "description" in f.rule_id or "example" in f.rule_id or "output" in f.rule_id or "html" in f.rule_id
+
+
+class TestAnalyzerEnumRegistration:
+    def test_lint_in_analyzer_enum(self):
+        from mcpscanner.core.models import AnalyzerEnum
+        assert AnalyzerEnum.LINT.value == "lint"
+
+    def test_lint_engine_importable(self):
+        from mcpscanner.core.analyzers import LintEngine
+        assert LintEngine is not None
+
+
+class TestLintFinding:
+    def test_finding_to_dict(self):
+        from mcpscanner.core.analyzers.linter.finding import LintFinding, LintSeverity
+        f = LintFinding(
+            rule_id="test-rule",
+            severity=LintSeverity.WARNING,
+            category="tool",
+            message="msg",
+            recommendation="rec",
+            item_name="t",
+            affected_items=2,
+        )
+        d = f.to_dict()
+        assert d["rule_id"] == "test-rule"
+        assert d["severity"] == "warning"
+        assert d["affected_items"] == 2
+        assert "location" not in d
+
+    def test_finding_with_location(self):
+        from mcpscanner.core.analyzers.linter.finding import LintFinding, LintSeverity
+        f = LintFinding(
+            rule_id="test-rule",
+            severity=LintSeverity.INFO,
+            category="tool",
+            message="msg",
+            recommendation="rec",
+            location="inputSchema.properties.a",
+        )
+        d = f.to_dict()
+        assert d["location"] == "inputSchema.properties.a"
+
+
+class TestLintSeverity:
+    def test_ordering(self):
+        from mcpscanner.core.analyzers.linter.finding import LintSeverity
+        assert LintSeverity.ERROR < LintSeverity.WARNING
+        assert LintSeverity.WARNING < LintSeverity.INFO
+        assert LintSeverity.INFO < LintSeverity.HINT
+
+    def test_rank(self):
+        from mcpscanner.core.analyzers.linter.finding import LintSeverity
+        assert LintSeverity.ERROR.rank == 0
+        assert LintSeverity.HINT.rank == 3

--- a/tests/linter/test_engine.py
+++ b/tests/linter/test_engine.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the LintEngine orchestrator."""
+
+import pytest
+
+from mcpscanner.core.analyzers.linter.engine import LintEngine
+from mcpscanner.core.analyzers.linter.finding import LintSeverity
+
+
+class TestLintEngineBasic:
+    def test_empty_input(self):
+        engine = LintEngine()
+        summary = engine.lint(tools=[], prompts=[], resources=[], target="test")
+        assert summary.total_findings > 0  # server-has-capabilities fires
+        assert summary.target == "test"
+        assert summary.tools_scanned == 0
+
+    def test_clean_tool(self):
+        engine = LintEngine()
+        tool = {
+            "name": "get_user",
+            "description": "Fetches a user record by their unique identifier from the database.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "user_id": {"type": "string", "description": "Unique user ID", "example": "usr_123"}
+                },
+                "required": ["user_id"],
+            },
+            "outputSchema": {"type": "object"},
+        }
+        summary = engine.lint(tools=[tool], target="test")
+        tool_findings = [f for f in summary.findings if f.category == "tool"]
+        assert len(tool_findings) == 0
+
+    def test_bad_tool_generates_findings(self):
+        engine = LintEngine()
+        tool = {"name": "", "description": ""}
+        summary = engine.lint(tools=[tool], target="test")
+        tool_findings = [f for f in summary.findings if f.category == "tool"]
+        assert len(tool_findings) > 0
+        rule_ids = {f.rule_id for f in tool_findings}
+        assert "tool-has-name" in rule_ids
+
+    def test_summary_counts(self):
+        engine = LintEngine()
+        tools = [
+            {"name": "a", "description": "Good enough description for the tool"},
+            {"name": "b"},
+        ]
+        prompts = [{"name": "p1", "description": "A prompt for testing purposes"}]
+        resources = [{"name": "r1", "uri": "file://x", "description": "d", "mimeType": "text/plain"}]
+        summary = engine.lint(tools=tools, prompts=prompts, resources=resources, target="t")
+        assert summary.tools_scanned == 2
+        assert summary.prompts_scanned == 1
+        assert summary.resources_scanned == 1
+        assert summary.rules_checked == 37
+        assert summary.total_findings == summary.rules_failed or summary.total_findings >= summary.rules_failed
+
+    def test_findings_sorted_by_severity(self):
+        engine = LintEngine()
+        tool = {"name": "", "description": ""}
+        summary = engine.lint(tools=[tool], target="test")
+        if len(summary.findings) > 1:
+            for i in range(len(summary.findings) - 1):
+                assert summary.findings[i].severity.rank <= summary.findings[i + 1].severity.rank
+
+    def test_multiple_tools(self):
+        engine = LintEngine()
+        tools = [{"name": f"tool_{i}"} for i in range(5)]
+        summary = engine.lint(tools=tools, target="test")
+        assert summary.tools_scanned == 5
+
+    def test_server_duplicate_names_detected(self):
+        engine = LintEngine()
+        tools = [{"name": "same", "description": "D" * 25}, {"name": "same", "description": "D" * 25}]
+        summary = engine.lint(tools=tools, target="test")
+        server_findings = [f for f in summary.findings if f.rule_id == "server-tool-names-unique"]
+        assert len(server_findings) == 1
+
+
+class TestLintEngineRulesets:
+    def test_recommended_has_all_rules(self):
+        engine = LintEngine(ruleset="recommended")
+        assert engine.registry.active_count == 37
+
+    def test_strict_promotes_info(self):
+        engine = LintEngine(ruleset="strict")
+        for rule in engine.registry.get_active_rules():
+            assert rule.severity != LintSeverity.INFO
+
+    def test_quality_only_doc_rules(self):
+        engine = LintEngine(ruleset="quality")
+        assert engine.registry.active_count < 37
+        for rule in engine.registry.get_active_rules():
+            assert "description" in rule.id or "example" in rule.id or "output" in rule.id or "html" in rule.id
+
+
+class TestLintEngineSummary:
+    def test_to_dict(self):
+        engine = LintEngine()
+        summary = engine.lint(tools=[{"name": "t"}], target="test")
+        d = summary.to_dict()
+        assert "target" in d
+        assert "findings" in d
+        assert isinstance(d["findings"], list)
+        assert "rules_checked" in d
+
+    def test_findings_by_severity(self):
+        engine = LintEngine()
+        summary = engine.lint(tools=[{"name": ""}], target="test")
+        for sev_name, count in summary.findings_by_severity.items():
+            assert count > 0
+            actual = len([f for f in summary.findings if f.severity.value == sev_name])
+            assert actual == count
+
+    def test_findings_by_category(self):
+        engine = LintEngine()
+        summary = engine.lint(tools=[{"name": "t"}], prompts=[{"name": "p"}], target="test")
+        for cat, count in summary.findings_by_category.items():
+            actual = len([f for f in summary.findings if f.category == cat])
+            assert actual == count

--- a/tests/linter/test_formatter.py
+++ b/tests/linter/test_formatter.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the lint output formatter."""
+
+import json
+
+import pytest
+
+from mcpscanner.core.analyzers.linter.engine import LintEngine
+from mcpscanner.core.analyzers.linter.formatter import LintFormatter
+
+
+@pytest.fixture
+def summary_with_findings():
+    engine = LintEngine()
+    tool = {"name": "", "description": ""}
+    return engine.lint(tools=[tool], target="https://example.com/mcp")
+
+
+@pytest.fixture
+def clean_summary():
+    engine = LintEngine()
+    tool = {
+        "name": "get_user",
+        "description": "Fetches a user record by their unique identifier from the database.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "user_id": {"type": "string", "description": "ID", "example": "123"}
+            },
+            "required": ["user_id"],
+        },
+        "outputSchema": {},
+    }
+    return engine.lint(tools=[tool], target="clean-server")
+
+
+class TestTableFormat:
+    def test_contains_quality_header(self, summary_with_findings):
+        fmt = LintFormatter(summary_with_findings)
+        output = fmt.format_table()
+        assert "Quality" in output
+
+    def test_contains_severity(self, summary_with_findings):
+        fmt = LintFormatter(summary_with_findings)
+        output = fmt.format_table()
+        assert "error" in output.lower() or "warning" in output.lower() or "info" in output.lower()
+
+    def test_contains_rule_id(self, summary_with_findings):
+        fmt = LintFormatter(summary_with_findings)
+        output = fmt.format_table()
+        assert "tool-has-name" in output
+
+    def test_contains_summary_block(self, summary_with_findings):
+        fmt = LintFormatter(summary_with_findings)
+        output = fmt.format_table()
+        assert "Summary" in output
+        assert "Rules checked:" in output
+        assert "Rules passed:" in output
+
+    def test_contains_findings_count_line(self, summary_with_findings):
+        fmt = LintFormatter(summary_with_findings)
+        output = fmt.format_table()
+        assert "Findings" in output
+        assert "Error" in output
+
+    def test_clean_summary_zero_findings(self, clean_summary):
+        fmt = LintFormatter(clean_summary)
+        output = fmt.format_table()
+        assert "0 Findings" in output or clean_summary.total_findings == 0
+
+
+class TestSummaryFormat:
+    def test_contains_summary_header(self, summary_with_findings):
+        fmt = LintFormatter(summary_with_findings)
+        output = fmt.format_summary()
+        assert "Summary" in output
+
+    def test_contains_scanned(self, summary_with_findings):
+        fmt = LintFormatter(summary_with_findings)
+        output = fmt.format_summary()
+        assert "Scanned:" in output
+
+    def test_contains_rules_info(self, summary_with_findings):
+        fmt = LintFormatter(summary_with_findings)
+        output = fmt.format_summary()
+        assert "Rules checked:" in output
+        assert "Rules failed:" in output
+
+
+class TestJsonFormat:
+    def test_valid_json(self, summary_with_findings):
+        fmt = LintFormatter(summary_with_findings)
+        output = fmt.format_json()
+        data = json.loads(output)
+        assert "target" in data
+        assert "findings" in data
+        assert isinstance(data["findings"], list)
+
+    def test_json_has_all_fields(self, summary_with_findings):
+        fmt = LintFormatter(summary_with_findings)
+        data = json.loads(fmt.format_json())
+        assert data["target"] == "https://example.com/mcp"
+        assert "rules_checked" in data
+        assert "rules_passed" in data
+        assert "total_findings" in data
+
+    def test_json_finding_structure(self, summary_with_findings):
+        fmt = LintFormatter(summary_with_findings)
+        data = json.loads(fmt.format_json())
+        if data["findings"]:
+            f = data["findings"][0]
+            assert "rule_id" in f
+            assert "severity" in f
+            assert "category" in f
+            assert "message" in f
+            assert "recommendation" in f
+
+
+class TestFormatDispatch:
+    def test_table(self, summary_with_findings):
+        fmt = LintFormatter(summary_with_findings)
+        assert "Quality" in fmt.format("table")
+
+    def test_summary(self, summary_with_findings):
+        fmt = LintFormatter(summary_with_findings)
+        assert "Summary" in fmt.format("summary")
+
+    def test_json(self, summary_with_findings):
+        fmt = LintFormatter(summary_with_findings)
+        json.loads(fmt.format("json"))
+
+    def test_default_is_table(self, summary_with_findings):
+        fmt = LintFormatter(summary_with_findings)
+        assert fmt.format() == fmt.format("table")

--- a/tests/linter/test_rules_prompt.py
+++ b/tests/linter/test_rules_prompt.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the 8 built-in prompt lint rules."""
+
+import pytest
+
+from mcpscanner.core.analyzers.linter.rules.prompt_rules import PROMPT_RULES
+
+CTX = {}
+
+
+def _find_rule(rule_id):
+    for r in PROMPT_RULES:
+        if r.id == rule_id:
+            return r
+    raise ValueError(f"Rule {rule_id} not found")
+
+
+class TestPromptHasName:
+    RULE = _find_rule("prompt-has-name")
+
+    def test_pass(self):
+        assert self.RULE.check({"name": "greet"}, CTX) == []
+
+    def test_fail_empty(self):
+        assert len(self.RULE.check({"name": ""}, CTX)) == 1
+
+    def test_fail_missing(self):
+        assert len(self.RULE.check({}, CTX)) == 1
+
+
+class TestPromptHasDescription:
+    RULE = _find_rule("prompt-has-description")
+
+    def test_pass(self):
+        assert self.RULE.check({"name": "p", "description": "Does something"}, CTX) == []
+
+    def test_fail(self):
+        assert len(self.RULE.check({"name": "p"}, CTX)) == 1
+
+
+class TestPromptDescriptionMinLength:
+    RULE = _find_rule("prompt-description-min-length")
+
+    def test_pass(self):
+        assert self.RULE.check({"name": "p", "description": "A" * 20}, CTX) == []
+
+    def test_fail(self):
+        assert len(self.RULE.check({"name": "p", "description": "Short"}, CTX)) == 1
+
+    def test_pass_empty(self):
+        assert self.RULE.check({"name": "p", "description": ""}, CTX) == []
+
+
+class TestPromptNameConvention:
+    RULE = _find_rule("prompt-name-convention")
+
+    def test_pass_snake(self):
+        assert self.RULE.check({"name": "code_review"}, CTX) == []
+
+    def test_pass_camel(self):
+        assert self.RULE.check({"name": "codeReview"}, CTX) == []
+
+    def test_pass_kebab(self):
+        assert self.RULE.check({"name": "code-review"}, CTX) == []
+
+    def test_fail(self):
+        assert len(self.RULE.check({"name": "Code Review!"}, CTX)) == 1
+
+
+class TestPromptHasArguments:
+    RULE = _find_rule("prompt-has-arguments")
+
+    def test_pass_with_args(self):
+        assert self.RULE.check({"name": "p", "arguments": []}, CTX) == []
+
+    def test_fail_no_args(self):
+        assert len(self.RULE.check({"name": "p"}, CTX)) == 1
+
+
+class TestPromptArgumentHasDescription:
+    RULE = _find_rule("prompt-argument-has-description")
+
+    def test_pass(self):
+        prompt = {"name": "p", "arguments": [{"name": "a", "description": "desc"}]}
+        assert self.RULE.check(prompt, CTX) == []
+
+    def test_fail(self):
+        prompt = {"name": "p", "arguments": [{"name": "a"}]}
+        findings = self.RULE.check(prompt, CTX)
+        assert len(findings) == 1
+
+    def test_multiple_missing(self):
+        prompt = {"name": "p", "arguments": [{"name": "a"}, {"name": "b"}]}
+        findings = self.RULE.check(prompt, CTX)
+        assert findings[0].affected_items == 2
+
+
+class TestPromptArgumentHasRequired:
+    RULE = _find_rule("prompt-argument-has-required")
+
+    def test_pass(self):
+        prompt = {"name": "p", "arguments": [{"name": "a", "required": True}]}
+        assert self.RULE.check(prompt, CTX) == []
+
+    def test_fail(self):
+        prompt = {"name": "p", "arguments": [{"name": "a"}]}
+        findings = self.RULE.check(prompt, CTX)
+        assert len(findings) == 1
+
+
+class TestPromptNoDuplicateArguments:
+    RULE = _find_rule("prompt-no-duplicate-arguments")
+
+    def test_pass_unique(self):
+        prompt = {"name": "p", "arguments": [{"name": "a"}, {"name": "b"}]}
+        assert self.RULE.check(prompt, CTX) == []
+
+    def test_fail_duplicate(self):
+        prompt = {"name": "p", "arguments": [{"name": "a"}, {"name": "a"}]}
+        findings = self.RULE.check(prompt, CTX)
+        assert len(findings) == 1
+        assert findings[0].severity.value == "error"
+
+
+class TestPromptRulesCount:
+    def test_total_rules(self):
+        assert len(PROMPT_RULES) == 8
+
+    def test_unique_ids(self):
+        ids = [r.id for r in PROMPT_RULES]
+        assert len(ids) == len(set(ids))
+
+    def test_all_prompt_category(self):
+        assert all(r.category == "prompt" for r in PROMPT_RULES)

--- a/tests/linter/test_rules_resource.py
+++ b/tests/linter/test_rules_resource.py
@@ -1,0 +1,115 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the 6 built-in resource lint rules."""
+
+import pytest
+
+from mcpscanner.core.analyzers.linter.rules.resource_rules import RESOURCE_RULES
+
+CTX = {}
+
+
+def _find_rule(rule_id):
+    for r in RESOURCE_RULES:
+        if r.id == rule_id:
+            return r
+    raise ValueError(f"Rule {rule_id} not found")
+
+
+class TestResourceHasName:
+    RULE = _find_rule("resource-has-name")
+
+    def test_pass(self):
+        assert self.RULE.check({"name": "config", "uri": "file://config.json"}, CTX) == []
+
+    def test_fail_empty(self):
+        assert len(self.RULE.check({"name": "", "uri": "file://x"}, CTX)) == 1
+
+    def test_fail_missing(self):
+        assert len(self.RULE.check({"uri": "file://x"}, CTX)) == 1
+
+
+class TestResourceHasDescription:
+    RULE = _find_rule("resource-has-description")
+
+    def test_pass(self):
+        assert self.RULE.check({"name": "r", "description": "desc"}, CTX) == []
+
+    def test_fail(self):
+        assert len(self.RULE.check({"name": "r"}, CTX)) == 1
+
+
+class TestResourceHasMimeType:
+    RULE = _find_rule("resource-has-mime-type")
+
+    def test_pass(self):
+        assert self.RULE.check({"name": "r", "mimeType": "application/json"}, CTX) == []
+
+    def test_fail(self):
+        assert len(self.RULE.check({"name": "r"}, CTX)) == 1
+
+
+class TestResourceMimeTypeValid:
+    RULE = _find_rule("resource-mime-type-valid")
+
+    def test_pass_json(self):
+        assert self.RULE.check({"name": "r", "mimeType": "application/json"}, CTX) == []
+
+    def test_pass_text(self):
+        assert self.RULE.check({"name": "r", "mimeType": "text/plain"}, CTX) == []
+
+    def test_fail_invalid(self):
+        findings = self.RULE.check({"name": "r", "mimeType": "not-a-mime"}, CTX)
+        assert len(findings) == 1
+
+    def test_pass_no_mime(self):
+        assert self.RULE.check({"name": "r"}, CTX) == []
+
+
+class TestResourceUriValid:
+    RULE = _find_rule("resource-uri-valid")
+
+    def test_pass_file_uri(self):
+        assert self.RULE.check({"name": "r", "uri": "file://config.json"}, CTX) == []
+
+    def test_pass_https_uri(self):
+        assert self.RULE.check({"name": "r", "uri": "https://example.com/data"}, CTX) == []
+
+    def test_fail_no_scheme(self):
+        findings = self.RULE.check({"name": "r", "uri": "just-a-path"}, CTX)
+        assert len(findings) == 1
+
+    def test_fail_empty(self):
+        findings = self.RULE.check({"name": "r", "uri": ""}, CTX)
+        assert len(findings) == 1
+
+    def test_fail_missing(self):
+        findings = self.RULE.check({"name": "r"}, CTX)
+        assert len(findings) == 1
+
+
+class TestResourceNameConvention:
+    RULE = _find_rule("resource-name-convention")
+
+    def test_pass_snake(self):
+        assert self.RULE.check({"name": "project_config"}, CTX) == []
+
+    def test_pass_phrase(self):
+        assert self.RULE.check({"name": "Project Configuration"}, CTX) == []
+
+    def test_fail_weird(self):
+        findings = self.RULE.check({"name": "  weird  name  "}, CTX)
+        assert len(findings) == 1
+
+
+class TestResourceRulesCount:
+    def test_total_rules(self):
+        assert len(RESOURCE_RULES) == 6
+
+    def test_unique_ids(self):
+        ids = [r.id for r in RESOURCE_RULES]
+        assert len(ids) == len(set(ids))
+
+    def test_all_resource_category(self):
+        assert all(r.category == "resource" for r in RESOURCE_RULES)

--- a/tests/linter/test_rules_server.py
+++ b/tests/linter/test_rules_server.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the 5 built-in server lint rules."""
+
+import pytest
+
+from mcpscanner.core.analyzers.linter.rules.server_rules import SERVER_RULES
+
+CTX = {}
+
+
+def _find_rule(rule_id):
+    for r in SERVER_RULES:
+        if r.id == rule_id:
+            return r
+    raise ValueError(f"Rule {rule_id} not found")
+
+
+class TestServerHasCapabilities:
+    RULE = _find_rule("server-has-capabilities")
+
+    def test_pass_with_tools(self):
+        assert self.RULE.check({"tools": [{"name": "t"}], "prompts": [], "resources": []}, CTX) == []
+
+    def test_pass_with_prompts(self):
+        assert self.RULE.check({"tools": [], "prompts": [{"name": "p"}], "resources": []}, CTX) == []
+
+    def test_pass_with_resources(self):
+        assert self.RULE.check({"tools": [], "prompts": [], "resources": [{"name": "r"}]}, CTX) == []
+
+    def test_fail_empty(self):
+        findings = self.RULE.check({"tools": [], "prompts": [], "resources": []}, CTX)
+        assert len(findings) == 1
+
+
+class TestServerToolNamesUnique:
+    RULE = _find_rule("server-tool-names-unique")
+
+    def test_pass_unique(self):
+        server = {"tools": [{"name": "a"}, {"name": "b"}]}
+        assert self.RULE.check(server, CTX) == []
+
+    def test_fail_duplicate(self):
+        server = {"tools": [{"name": "a"}, {"name": "a"}]}
+        findings = self.RULE.check(server, CTX)
+        assert len(findings) == 1
+        assert "a" in findings[0].message
+
+    def test_pass_empty(self):
+        assert self.RULE.check({"tools": []}, CTX) == []
+
+
+class TestServerPromptNamesUnique:
+    RULE = _find_rule("server-prompt-names-unique")
+
+    def test_pass_unique(self):
+        server = {"prompts": [{"name": "a"}, {"name": "b"}]}
+        assert self.RULE.check(server, CTX) == []
+
+    def test_fail_duplicate(self):
+        server = {"prompts": [{"name": "x"}, {"name": "x"}]}
+        findings = self.RULE.check(server, CTX)
+        assert len(findings) == 1
+
+
+class TestServerResourceUrisUnique:
+    RULE = _find_rule("server-resource-uris-unique")
+
+    def test_pass_unique(self):
+        server = {"resources": [{"uri": "file://a"}, {"uri": "file://b"}]}
+        assert self.RULE.check(server, CTX) == []
+
+    def test_fail_duplicate(self):
+        server = {"resources": [{"uri": "file://a"}, {"uri": "file://a"}]}
+        findings = self.RULE.check(server, CTX)
+        assert len(findings) == 1
+
+
+class TestServerNoExcessiveTools:
+    RULE = _find_rule("server-no-excessive-tools")
+
+    def test_pass_few_tools(self):
+        server = {"tools": [{"name": f"t{i}"} for i in range(10)]}
+        assert self.RULE.check(server, CTX) == []
+
+    def test_fail_too_many(self):
+        server = {"tools": [{"name": f"t{i}"} for i in range(101)]}
+        findings = self.RULE.check(server, CTX)
+        assert len(findings) == 1
+
+    def test_pass_at_limit(self):
+        server = {"tools": [{"name": f"t{i}"} for i in range(100)]}
+        assert self.RULE.check(server, CTX) == []
+
+
+class TestServerRulesCount:
+    def test_total_rules(self):
+        assert len(SERVER_RULES) == 5
+
+    def test_unique_ids(self):
+        ids = [r.id for r in SERVER_RULES]
+        assert len(ids) == len(set(ids))
+
+    def test_all_server_category(self):
+        assert all(r.category == "server" for r in SERVER_RULES)

--- a/tests/linter/test_rules_tool.py
+++ b/tests/linter/test_rules_tool.py
@@ -1,0 +1,376 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the 18 built-in tool lint rules."""
+
+import pytest
+
+from mcpscanner.core.analyzers.linter.rules.tool_rules import TOOL_RULES
+
+CTX = {}
+
+
+def _find_rule(rule_id):
+    for r in TOOL_RULES:
+        if r.id == rule_id:
+            return r
+    raise ValueError(f"Rule {rule_id} not found")
+
+
+# ---- tool-has-name ----
+
+class TestToolHasName:
+    RULE = _find_rule("tool-has-name")
+
+    def test_pass_with_name(self):
+        assert self.RULE.check({"name": "my_tool"}, CTX) == []
+
+    def test_fail_empty_name(self):
+        findings = self.RULE.check({"name": ""}, CTX)
+        assert len(findings) == 1
+        assert findings[0].severity.value == "error"
+
+    def test_fail_missing_name(self):
+        findings = self.RULE.check({}, CTX)
+        assert len(findings) == 1
+
+    def test_fail_whitespace_name(self):
+        findings = self.RULE.check({"name": "   "}, CTX)
+        assert len(findings) == 1
+
+
+# ---- tool-has-description ----
+
+class TestToolHasDescription:
+    RULE = _find_rule("tool-has-description")
+
+    def test_pass(self):
+        assert self.RULE.check({"name": "t", "description": "Does something"}, CTX) == []
+
+    def test_fail_missing(self):
+        findings = self.RULE.check({"name": "t"}, CTX)
+        assert len(findings) == 1
+        assert findings[0].severity.value == "warning"
+
+    def test_fail_empty(self):
+        findings = self.RULE.check({"name": "t", "description": ""}, CTX)
+        assert len(findings) == 1
+
+
+# ---- tool-description-min-length ----
+
+class TestToolDescriptionMinLength:
+    RULE = _find_rule("tool-description-min-length")
+
+    def test_pass_long_enough(self):
+        assert self.RULE.check({"name": "t", "description": "A" * 20}, CTX) == []
+
+    def test_pass_no_description(self):
+        assert self.RULE.check({"name": "t"}, CTX) == []
+
+    def test_fail_too_short(self):
+        findings = self.RULE.check({"name": "t", "description": "Short"}, CTX)
+        assert len(findings) == 1
+        assert findings[0].severity.value == "info"
+
+
+# ---- tool-description-not-name ----
+
+class TestToolDescriptionNotName:
+    RULE = _find_rule("tool-description-not-name")
+
+    def test_pass_different(self):
+        assert self.RULE.check({"name": "get_user", "description": "Fetches a user by ID"}, CTX) == []
+
+    def test_fail_same(self):
+        findings = self.RULE.check({"name": "get_user", "description": "get_user"}, CTX)
+        assert len(findings) == 1
+
+    def test_fail_case_insensitive(self):
+        findings = self.RULE.check({"name": "get_user", "description": "Get User"}, CTX)
+        assert len(findings) == 1
+
+    def test_pass_empty_desc(self):
+        assert self.RULE.check({"name": "t", "description": ""}, CTX) == []
+
+
+# ---- tool-name-convention ----
+
+class TestToolNameConvention:
+    RULE = _find_rule("tool-name-convention")
+
+    def test_pass_snake_case(self):
+        assert self.RULE.check({"name": "get_user_data"}, CTX) == []
+
+    def test_pass_camel_case(self):
+        assert self.RULE.check({"name": "getUserData"}, CTX) == []
+
+    def test_fail_spaces(self):
+        findings = self.RULE.check({"name": "Get User Data"}, CTX)
+        assert len(findings) == 1
+
+    def test_fail_pascal_case(self):
+        findings = self.RULE.check({"name": "GetUserData"}, CTX)
+        assert len(findings) == 1
+
+    def test_pass_empty(self):
+        assert self.RULE.check({"name": ""}, CTX) == []
+
+
+# ---- tool-name-max-length ----
+
+class TestToolNameMaxLength:
+    RULE = _find_rule("tool-name-max-length")
+
+    def test_pass_normal_length(self):
+        assert self.RULE.check({"name": "my_tool"}, CTX) == []
+
+    def test_fail_too_long(self):
+        findings = self.RULE.check({"name": "a" * 65}, CTX)
+        assert len(findings) == 1
+
+    def test_pass_exact_limit(self):
+        assert self.RULE.check({"name": "a" * 64}, CTX) == []
+
+
+# ---- tool-has-input-schema ----
+
+class TestToolHasInputSchema:
+    RULE = _find_rule("tool-has-input-schema")
+
+    def test_pass(self):
+        assert self.RULE.check({"name": "t", "inputSchema": {"type": "object"}}, CTX) == []
+
+    def test_fail(self):
+        findings = self.RULE.check({"name": "t"}, CTX)
+        assert len(findings) == 1
+
+
+# ---- tool-input-schema-has-properties ----
+
+class TestToolInputSchemaHasProperties:
+    RULE = _find_rule("tool-input-schema-has-properties")
+
+    def test_pass_with_properties(self):
+        tool = {"name": "t", "inputSchema": {"type": "object", "properties": {"a": {"type": "string"}}}}
+        assert self.RULE.check(tool, CTX) == []
+
+    def test_fail_no_properties(self):
+        tool = {"name": "t", "inputSchema": {"type": "object"}}
+        findings = self.RULE.check(tool, CTX)
+        assert len(findings) == 1
+
+    def test_pass_no_schema(self):
+        assert self.RULE.check({"name": "t"}, CTX) == []
+
+
+# ---- tool-input-schema-has-required ----
+
+class TestToolInputSchemaHasRequired:
+    RULE = _find_rule("tool-input-schema-has-required")
+
+    def test_pass_with_required(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {}}, "required": ["a"]}}
+        assert self.RULE.check(tool, CTX) == []
+
+    def test_fail_no_required(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {}}}}
+        findings = self.RULE.check(tool, CTX)
+        assert len(findings) == 1
+
+    def test_pass_no_properties(self):
+        tool = {"name": "t", "inputSchema": {}}
+        assert self.RULE.check(tool, CTX) == []
+
+
+# ---- tool-required-params-defined ----
+
+class TestToolRequiredParamsDefined:
+    RULE = _find_rule("tool-required-params-defined")
+
+    def test_pass_all_defined(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {}}, "required": ["a"]}}
+        assert self.RULE.check(tool, CTX) == []
+
+    def test_fail_undefined_param(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {}}, "required": ["a", "b"]}}
+        findings = self.RULE.check(tool, CTX)
+        assert len(findings) == 1
+        assert "b" in findings[0].message
+
+    def test_pass_no_required(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {}}}}
+        assert self.RULE.check(tool, CTX) == []
+
+
+# ---- tool-schema-properties-have-types ----
+
+class TestToolSchemaPropertiesHaveTypes:
+    RULE = _find_rule("tool-schema-properties-have-types")
+
+    def test_pass_all_typed(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {"type": "string"}}}}
+        assert self.RULE.check(tool, CTX) == []
+
+    def test_fail_untyped(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {"description": "no type"}}}}
+        findings = self.RULE.check(tool, CTX)
+        assert len(findings) == 1
+        assert "a" in findings[0].message
+
+    def test_pass_empty_properties(self):
+        tool = {"name": "t", "inputSchema": {"properties": {}}}
+        assert self.RULE.check(tool, CTX) == []
+
+
+# ---- tool-schema-properties-have-descriptions ----
+
+class TestToolSchemaPropertiesHaveDescriptions:
+    RULE = _find_rule("tool-schema-properties-have-descriptions")
+
+    def test_pass_all_described(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {"description": "desc"}}}}
+        assert self.RULE.check(tool, CTX) == []
+
+    def test_fail_undescribed(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {"type": "string"}}}}
+        findings = self.RULE.check(tool, CTX)
+        assert len(findings) == 1
+
+    def test_multiple_undescribed(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {}, "b": {}}}}
+        findings = self.RULE.check(tool, CTX)
+        assert len(findings) == 1
+        assert findings[0].affected_items == 2
+
+
+# ---- tool-schema-has-examples ----
+
+class TestToolSchemaHasExamples:
+    RULE = _find_rule("tool-schema-has-examples")
+
+    def test_pass_with_example(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {"example": "foo"}}}}
+        assert self.RULE.check(tool, CTX) == []
+
+    def test_pass_with_default(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {"default": "bar"}}}}
+        assert self.RULE.check(tool, CTX) == []
+
+    def test_pass_with_examples(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {"examples": ["x"]}}}}
+        assert self.RULE.check(tool, CTX) == []
+
+    def test_fail_no_example(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {"type": "string"}}}}
+        findings = self.RULE.check(tool, CTX)
+        assert len(findings) == 1
+
+
+# ---- tool-output-schema-defined ----
+
+class TestToolOutputSchemaDefined:
+    RULE = _find_rule("tool-output-schema-defined")
+
+    def test_pass(self):
+        assert self.RULE.check({"name": "t", "outputSchema": {}}, CTX) == []
+
+    def test_fail(self):
+        findings = self.RULE.check({"name": "t"}, CTX)
+        assert len(findings) == 1
+
+
+# ---- tool-no-empty-enum ----
+
+class TestToolNoEmptyEnum:
+    RULE = _find_rule("tool-no-empty-enum")
+
+    def test_pass_no_enum(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {"type": "string"}}}}
+        assert self.RULE.check(tool, CTX) == []
+
+    def test_pass_populated_enum(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {"type": "string", "enum": ["x", "y"]}}}}
+        assert self.RULE.check(tool, CTX) == []
+
+    def test_fail_empty_enum(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {"type": "string", "enum": []}}}}
+        findings = self.RULE.check(tool, CTX)
+        assert len(findings) == 1
+
+
+# ---- tool-schema-max-depth ----
+
+class TestToolSchemaMaxDepth:
+    RULE = _find_rule("tool-schema-max-depth")
+
+    def test_pass_shallow(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {"type": "string"}}}}
+        assert self.RULE.check(tool, CTX) == []
+
+    def test_fail_deep(self):
+        nested = {"type": "object", "properties": {
+            "l1": {"type": "object", "properties": {
+                "l2": {"type": "object", "properties": {
+                    "l3": {"type": "object", "properties": {
+                        "l4": {"type": "object", "properties": {
+                            "l5": {"type": "object", "properties": {
+                                "l6": {"type": "string"}
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        }}
+        tool = {"name": "t", "inputSchema": nested}
+        findings = self.RULE.check(tool, CTX)
+        assert len(findings) == 1
+
+
+# ---- tool-no-duplicate-params ----
+
+class TestToolNoDuplicateParams:
+    RULE = _find_rule("tool-no-duplicate-params")
+
+    def test_pass_unique(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"a": {}, "b": {}}}}
+        assert self.RULE.check(tool, CTX) == []
+
+    def test_fail_case_insensitive_dup(self):
+        tool = {"name": "t", "inputSchema": {"properties": {"Param": {}, "param": {}}}}
+        findings = self.RULE.check(tool, CTX)
+        assert len(findings) == 1
+
+
+# ---- tool-description-no-html ----
+
+class TestToolDescriptionNoHtml:
+    RULE = _find_rule("tool-description-no-html")
+
+    def test_pass_plain(self):
+        assert self.RULE.check({"name": "t", "description": "Simple text"}, CTX) == []
+
+    def test_fail_html(self):
+        findings = self.RULE.check({"name": "t", "description": "<p>HTML</p>"}, CTX)
+        assert len(findings) == 1
+
+    def test_fail_bold(self):
+        findings = self.RULE.check({"name": "t", "description": "Some <b>bold</b>"}, CTX)
+        assert len(findings) == 1
+
+    def test_pass_angle_brackets_in_code(self):
+        assert self.RULE.check({"name": "t", "description": "Returns x < 5 and y > 3"}, CTX) == []
+
+
+# ---- Aggregate checks ----
+
+class TestToolRulesCount:
+    def test_total_rules(self):
+        assert len(TOOL_RULES) == 18
+
+    def test_unique_ids(self):
+        ids = [r.id for r in TOOL_RULES]
+        assert len(ids) == len(set(ids))
+
+    def test_all_tool_category(self):
+        assert all(r.category == "tool" for r in TOOL_RULES)

--- a/tests/linter/test_rulesets.py
+++ b/tests/linter/test_rulesets.py
@@ -1,0 +1,99 @@
+# Copyright 2026 Cisco Systems, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ruleset configuration and YAML overrides."""
+
+import pytest
+
+from mcpscanner.core.analyzers.linter.finding import LintSeverity
+from mcpscanner.core.analyzers.linter.rulesets import build_registry, QUALITY_RULE_IDS
+from mcpscanner.core.analyzers.linter.rules import ALL_RULES
+from mcpscanner.core.analyzers.linter.config import LintConfig
+
+
+class TestBuildRegistry:
+    def test_recommended_loads_all(self):
+        reg = build_registry("recommended")
+        assert reg.total_rules == 37
+        assert reg.active_count == 37
+
+    def test_strict_promotes_info_to_warning(self):
+        reg = build_registry("strict")
+        for rule in reg.get_active_rules():
+            assert rule.severity in (LintSeverity.ERROR, LintSeverity.WARNING)
+
+    def test_quality_disables_non_doc_rules(self):
+        reg = build_registry("quality")
+        active_ids = {r.id for r in reg.get_active_rules()}
+        assert active_ids.issubset(QUALITY_RULE_IDS)
+
+    def test_quality_keeps_doc_rules(self):
+        reg = build_registry("quality")
+        active_ids = {r.id for r in reg.get_active_rules()}
+        assert "tool-has-description" in active_ids
+        assert "tool-schema-has-examples" in active_ids
+
+    def test_override_disable(self):
+        reg = build_registry("recommended", overrides={"tool-has-name": "off"})
+        active_ids = {r.id for r in reg.get_active_rules()}
+        assert "tool-has-name" not in active_ids
+
+    def test_override_severity(self):
+        reg = build_registry("recommended", overrides={"tool-output-schema-defined": "warning"})
+        rule = reg.get_rule("tool-output-schema-defined")
+        # Re-fetch via active rules to ensure override applied
+        for r in reg.get_active_rules():
+            if r.id == "tool-output-schema-defined":
+                assert r.severity == LintSeverity.WARNING
+
+    def test_override_invalid_severity_ignored(self):
+        reg = build_registry("recommended", overrides={"tool-has-name": "critical"})
+        active_ids = {r.id for r in reg.get_active_rules()}
+        assert "tool-has-name" in active_ids
+
+
+class TestLintConfig:
+    def test_default(self):
+        cfg = LintConfig.default()
+        assert cfg.extends == "recommended"
+        assert cfg.rules == {}
+
+    def test_load_nonexistent_file(self):
+        cfg = LintConfig.from_file("/nonexistent/path.yaml")
+        assert cfg.extends == "recommended"
+
+    def test_load_none(self):
+        cfg = LintConfig.load(None)
+        assert cfg.extends == "recommended"
+
+
+class TestRuleRegistryOperations:
+    def test_register_and_get(self):
+        reg = build_registry()
+        rule = reg.get_rule("tool-has-name")
+        assert rule is not None
+        assert rule.id == "tool-has-name"
+
+    def test_disable_enable(self):
+        reg = build_registry()
+        reg.disable("tool-has-name")
+        active_ids = {r.id for r in reg.get_active_rules()}
+        assert "tool-has-name" not in active_ids
+        reg.enable("tool-has-name")
+        active_ids = {r.id for r in reg.get_active_rules()}
+        assert "tool-has-name" in active_ids
+
+    def test_get_active_by_category(self):
+        reg = build_registry()
+        tool_rules = reg.get_active_rules(category="tool")
+        assert all(r.category == "tool" for r in tool_rules)
+        prompt_rules = reg.get_active_rules(category="prompt")
+        assert all(r.category == "prompt" for r in prompt_rules)
+
+    def test_all_rule_ids(self):
+        reg = build_registry()
+        assert len(reg.all_rule_ids) == 37
+
+    def test_get_nonexistent_rule(self):
+        reg = build_registry()
+        assert reg.get_rule("nonexistent") is None


### PR DESCRIPTION
## Summary

- Adds a rule-driven MCP schema linter (`mcp-scanner lint`) that validates tool, prompt, and resource definitions for quality, completeness, and consistency
- 37 built-in rules across 4 categories (tool: 18, prompt: 8, resource: 6, server: 5) with 3 predefined rulesets (`recommended`, `strict`, `quality`) and YAML config support
- Supports all input modes: remote URL (`--server-url`), stdio (`--stdio-command`), and static files (`--tools-file`) with table, summary, and JSON output formats

## Example Output

### Remote server (table format)
$ mcp-scanner lint --server-url https://mcp.deepwiki.com/mcp

Tool Quality
      #  SEVERITY  CODE                                 FINDINGS                                RECOMMENDATION                          AFFECTED ITEMS
      1  warning   tool-schema-properties-have-types    Tool 'ask_question' properties miss...  Add a 'type' field (e.g. 'string', ...               1
      2  info      tool-schema-properties-have-descriptions Tool 'read_wiki_structure' proper...  Add a 'description' to each propert...               1
      3  info      tool-schema-has-examples             Tool 'read_wiki_structure' properti...  Add 'example' field to properties f...               1
      ...

7 Findings (0 Error, 1 Warning, 6 Info, 0 Hint)
    # | CATEGORY     | ERROR | WARNING | INFO | HINT
    1 | Tool         |     0 |       1 |    6 |    0

Summary
  Scanned:       3 tools
  Rules checked: 37
  Rules passed:  34 (92%)
  Rules failed:  3
  Total issues:  7

### Strict ruleset (all info promoted to warning)
$ mcp-scanner lint --server-url https://mcp.deepwiki.com/mcp --ruleset strict
7 Findings (0 Error, 7 Warning, 0 Info, 0 Hint)

### Stdio server
$ mcp-scanner lint --stdio-command uvx --stdio-args mcp-server-fetch
Summary: Scanned 1 tools, 1 prompts | Rules passed: 36 (97%) | Total issues: 1

### JSON output (CI/CD friendly)
{
  "target": "https://mcp.deepwiki.com/mcp",
  "tools_scanned": 3,
  "rules_checked": 37,
  "rules_passed": 34,
  "total_findings": 7,
  "findings": [...]
}

### YAML config overrides
extends: recommended
rules:
  tool-output-schema-defined: off
  tool-schema-has-examples: warning