### PR TITLE
feat: add configurable stdio timeout via --stdio-timeout flag and MCP_SCANNER_STDIO_TIMEOUT env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,18 @@ export MCP_SCANNER_VT_MAX_FILES=10
 
 > **Note:** Without `VIRUSTOTAL_API_KEY`, files will not be scanned for malware. When enabled, the analyzer uses configurable inclusion/exclusion extension lists to determine which files to scan, skipping `__pycache__` and hidden directories.
 
+#### Stdio Connection Timeout
+
+When scanning stdio MCP servers, the scanner waits for the server process to start and respond. The default timeout is 60 seconds, which may be insufficient for servers that download large dependencies on first run. This setting only affects the stdio server connection; LLM/API call timeouts are controlled separately via `MCP_SCANNER_LLM_TIMEOUT`.
+
+```bash
+# Increase stdio server startup timeout (default: 60 seconds)
+export MCP_SCANNER_STDIO_TIMEOUT=180  # 3 minutes — useful for servers with heavy deps
+
+# Or use the CLI flag (overrides the environment variable)
+mcp-scanner --stdio-timeout 180 stdio --stdio-command uvx --stdio-arg mcp-clickhouse
+```
+
 #### Using a Local LLM (No API Key Required)
 
 If you are using a local LLM endpoint such as Ollama, vLLM, or LocalAI,
@@ -247,7 +259,7 @@ asyncio.run(main())
 #### Subcommands Overview
 
 - **remote**: scan a remote MCP server (SSE or streamable HTTP). Supports `--server-url`, optional `--bearer-token`, `--header`.
-- **stdio**: launch and scan a stdio MCP server. Requires `--stdio-command`; accepts `--stdio-args`, `--stdio-env`, optional `--stdio-tool`.
+- **stdio**: launch and scan a stdio MCP server. Requires `--stdio-command`; accepts `--stdio-args`, `--stdio-env`, optional `--stdio-tool`, `--stdio-timeout`.
 - **config**: scan servers from a specific MCP config file. Requires `--config-path`; optional `--bearer-token`.
 - **known-configs**: scan servers from well-known client config locations on this machine; optional `--bearer-token`.
 - **prompts**: scan prompts on an MCP server. Requires `--server-url`; optional `--prompt-name`, `--bearer-token`, `--header`.
@@ -298,6 +310,10 @@ mcp-scanner --analyzers yara --format summary \
   stdio --stdio-command uvx \
   --stdio-arg=--from --stdio-arg=mcp-server-fetch --stdio-arg=mcp-server-fetch \
   --stdio-tool fetch
+
+# Increase startup timeout for servers with heavy dependencies (default: 60s)
+mcp-scanner --stdio-timeout 180 --analyzers yara --format summary \
+  stdio --stdio-command uvx --stdio-arg mcp-clickhouse@0.1.13
 ```
 
 #### Use a Bearer token with remote servers (non-OAuth)

--- a/mcpscanner/cli.py
+++ b/mcpscanner/cli.py
@@ -129,6 +129,7 @@ def _build_config(
     llm_api_version = os.environ.get("MCP_SCANNER_LLM_API_VERSION")
     llm_model = os.environ.get("MCP_SCANNER_LLM_MODEL")
     llm_timeout = os.environ.get("MCP_SCANNER_LLM_TIMEOUT")
+    stdio_timeout = os.environ.get("MCP_SCANNER_STDIO_TIMEOUT")
     endpoint_url = endpoint_url or _get_endpoint_from_env()
 
     config_params = {
@@ -158,6 +159,8 @@ def _build_config(
         config_params["llm_api_version"] = llm_api_version
     if llm_timeout:
         config_params["llm_timeout"] = float(llm_timeout)
+    if stdio_timeout:
+        config_params["stdio_timeout"] = int(stdio_timeout)
 
     # VirusTotal configuration — pass API key so Config can wire it up;
     # remaining VT settings (max_files, extensions, etc.) fall back to
@@ -1150,6 +1153,11 @@ async def main():
         type=int,
         help="Timeout in seconds for LLM API calls (overrides MCP_SCANNER_LLM_TIMEOUT environment variable)",
     )
+    parser.add_argument(
+        "--stdio-timeout",
+        type=int,
+        help="Timeout in seconds for stdio server connections (overrides MCP_SCANNER_STDIO_TIMEOUT environment variable, default: 60)",
+    )
 
     parser.add_argument(
         "--analyzers",
@@ -1331,6 +1339,8 @@ async def main():
         os.environ["MCP_SCANNER_LLM_API_KEY"] = args.llm_api_key
     if args.llm_timeout:
         os.environ["MCP_SCANNER_LLM_TIMEOUT"] = str(args.llm_timeout)
+    if args.stdio_timeout:
+        os.environ["MCP_SCANNER_STDIO_TIMEOUT"] = str(args.stdio_timeout)
 
     try:
         # Handle static file scanning subcommand (matches 'prompts' and 'resources' pattern)

--- a/mcpscanner/config/config.py
+++ b/mcpscanner/config/config.py
@@ -57,6 +57,7 @@ class Config:
         aws_profile_name: str = None,
         aws_bearer_token_bedrock: str = None,
         llm_timeout: float = None,
+        stdio_timeout: int = None,
         oauth_client_id: str = None,
         oauth_client_secret: str = None,
         oauth_token_url: str = None,
@@ -124,6 +125,7 @@ class Config:
         self._aws_bearer_token_bedrock = aws_bearer_token_bedrock or os.getenv("AWS_BEARER_TOKEN_BEDROCK")
 
         self._llm_timeout = llm_timeout or CONSTANTS.DEFAULT_LLM_TIMEOUT
+        self._stdio_timeout = stdio_timeout or CONSTANTS.DEFAULT_STDIO_TIMEOUT
         self._oauth_client_id = oauth_client_id
         self._oauth_client_secret = oauth_client_secret
         self._oauth_token_url = oauth_token_url
@@ -280,6 +282,15 @@ class Config:
             float: The timeout in seconds.
         """
         return self._llm_timeout
+
+    @property
+    def stdio_timeout(self) -> int:
+        """Get the timeout for stdio server connections.
+
+        Returns:
+            int: The timeout in seconds.
+        """
+        return self._stdio_timeout
 
     @property
     def oauth_client_id(self) -> Optional[str]:

--- a/mcpscanner/config/constants.py
+++ b/mcpscanner/config/constants.py
@@ -127,6 +127,9 @@ class MCPScannerConstants:
     DEFAULT_LLM_API_VERSION: str = os.getenv("MCP_SCANNER_LLM_API_VERSION", None)
     DEFAULT_LLM_TIMEOUT: int = int(os.getenv("MCP_SCANNER_LLM_TIMEOUT", "30"))
 
+    # Stdio server connection timeout
+    DEFAULT_STDIO_TIMEOUT: int = int(os.getenv("MCP_SCANNER_STDIO_TIMEOUT", "60"))
+
     # LLM Prompt Configuration
     PROMPT_LENGTH_THRESHOLD: int = int(
         os.getenv("MCP_SCANNER_PROMPT_LENGTH_THRESHOLD", "75000")

--- a/mcpscanner/core/scanner.py
+++ b/mcpscanner/core/scanner.py
@@ -1308,14 +1308,14 @@ class Scanner:
         Args:
             server_config: The stdio server configuration
             analyzers: List of analyzers to use
-            timeout: Connection timeout in seconds
+            timeout: Connection timeout in seconds (defaults to config's stdio_timeout)
             errlog: Optional file-like object for stderr redirection
 
         Returns:
             List[ToolScanResult]: List of tool scan results
         """
         if timeout is None:
-            timeout = 60
+            timeout = self._config.stdio_timeout
 
         # Default to all analyzers if none specified
         if analyzers is None:
@@ -1378,7 +1378,7 @@ class Scanner:
             server_config (StdioServer): The stdio server configuration.
             tool_name (str): The name of the tool to scan.
             analyzers (Optional[List[AnalyzerEnum]]): List of analyzers to run. Defaults to all analyzers.
-            timeout (Optional[int]): Timeout for the connection.
+            timeout (Optional[int]): Timeout for the connection (defaults to config's stdio_timeout).
             errlog: Optional file-like object for stderr redirection.
 
         Returns:
@@ -1387,6 +1387,8 @@ class Scanner:
         Raises:
             ValueError: If the tool is not found on the server.
         """
+        if timeout is None:
+            timeout = self._config.stdio_timeout
         if not server_config.command:
             raise ValueError("No command provided in stdio server configuration.")
 
@@ -1901,13 +1903,13 @@ class Scanner:
         Args:
             server_config: The stdio server configuration
             analyzers: List of analyzers to use (defaults to API and LLM)
-            timeout: Connection timeout in seconds
+            timeout: Connection timeout in seconds (defaults to config's stdio_timeout)
 
         Returns:
             List of prompt scan results
         """
         if timeout is None:
-            timeout = 60
+            timeout = self._config.stdio_timeout
 
         # Default to API and LLM analyzers for prompts
         if analyzers is None:
@@ -1972,7 +1974,7 @@ class Scanner:
             server_config (StdioServer): The stdio server configuration.
             prompt_name (str): The name of the prompt to scan.
             analyzers (Optional[List[AnalyzerEnum]]): List of analyzers to run. Defaults to API and LLM.
-            timeout (Optional[int]): Timeout for the connection.
+            timeout (Optional[int]): Timeout for the connection (defaults to config's stdio_timeout).
 
         Returns:
             PromptScanResult: The result of the scan.
@@ -1980,6 +1982,8 @@ class Scanner:
         Raises:
             ValueError: If the prompt is not found on the server.
         """
+        if timeout is None:
+            timeout = self._config.stdio_timeout
         if not server_config.command:
             raise ValueError("No command provided in stdio server configuration.")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,6 +85,28 @@ class TestCliHelperFunctions:
             assert config.api_key == ""  # API not selected
             assert config.llm_provider_api_key == "test_llm_key"
 
+    def test_build_config_with_stdio_timeout(self):
+        """Test _build_config passes MCP_SCANNER_STDIO_TIMEOUT to Config."""
+        analyzers = [AnalyzerEnum.YARA]
+
+        with patch.dict(
+            "os.environ",
+            {"MCP_SCANNER_STDIO_TIMEOUT": "180"},
+        ):
+            config = _build_config(analyzers)
+            assert config.stdio_timeout == 180
+
+    def test_build_config_stdio_timeout_default(self):
+        """Test _build_config uses default stdio_timeout when env var is not set."""
+        analyzers = [AnalyzerEnum.YARA]
+
+        with patch.dict("os.environ", {}, clear=False):
+            env = dict(**{k: v for k, v in __import__("os").environ.items()})
+            env.pop("MCP_SCANNER_STDIO_TIMEOUT", None)
+            with patch.dict("os.environ", env, clear=True):
+                config = _build_config(analyzers)
+                assert config.stdio_timeout == 60
+
     def test_build_config_no_analyzers(self):
         """Test _build_config with no analyzers selected."""
         analyzers = []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,7 @@ class TestConfig:
         assert config.llm_temperature == CONSTANTS.DEFAULT_LLM_TEMPERATURE
         assert config.llm_rate_limit_delay == 1.0
         assert config.llm_max_retries == 3
+        assert config.stdio_timeout == CONSTANTS.DEFAULT_STDIO_TIMEOUT
 
     def test_config_initialization_with_api_key(self):
         """Test Config initialization with API key."""
@@ -137,6 +138,25 @@ class TestConfig:
         api_url = config.get_api_url("")
         assert api_url == "https://us.api.inspect.aidefense.security.cisco.com/api/v1/"
 
+    def test_config_stdio_timeout_custom(self):
+        """Test Config with custom stdio_timeout."""
+        config = Config(stdio_timeout=180)
+        assert config.stdio_timeout == 180
+
+    def test_config_stdio_timeout_default(self):
+        """Test Config falls back to CONSTANTS.DEFAULT_STDIO_TIMEOUT."""
+        config = Config()
+        assert config.stdio_timeout == CONSTANTS.DEFAULT_STDIO_TIMEOUT
+
+    def test_config_stdio_timeout_from_env(self):
+        """Test Config picks up MCP_SCANNER_STDIO_TIMEOUT from environment."""
+        with patch.dict("os.environ", {"MCP_SCANNER_STDIO_TIMEOUT": "300"}):
+            from mcpscanner.config.constants import MCPScannerConstants
+
+            fresh_default = int("300")
+            config = Config(stdio_timeout=fresh_default)
+            assert config.stdio_timeout == 300
+
     def test_config_all_parameters(self):
         """Test Config with all parameters set."""
         config = Config(
@@ -150,6 +170,7 @@ class TestConfig:
             llm_api_version="v1",
             llm_rate_limit_delay=1.5,
             llm_max_retries=2,
+            stdio_timeout=120,
             oauth_client_id="oauth_id",
             oauth_client_secret="oauth_secret",
             oauth_token_url="https://oauth.com/token",
@@ -167,6 +188,7 @@ class TestConfig:
         assert config.llm_api_version == "v1"
         assert config.llm_rate_limit_delay == 1.5
         assert config.llm_max_retries == 2
+        assert config.stdio_timeout == 120
         assert config.oauth_client_id == "oauth_id"
         assert config.oauth_client_secret == "oauth_secret"
         assert config.oauth_token_url == "https://oauth.com/token"


### PR DESCRIPTION
## Summary

When using `mcp-scanner stdio` to scan MCP servers, there is a hardcoded 60-second timeout for the server to start. This is insufficient for MCP servers with large dependencies that need to be downloaded and installed on first run (e.g. `mcp-clickhouse` downloads ~250MB+ of dependencies including `chdb`, `pyarrow`, `numpy`, `pandas`), especially in CI environments where dependency caching isn't always warm.

This PR adds a configurable timeout for stdio connections via:

- **CLI flag:** `--stdio-timeout <seconds>`
- **Environment variable:** `MCP_SCANNER_STDIO_TIMEOUT` (for CI/CD convenience)

The default remains **60 seconds** (no breaking change). The implementation follows the same pattern as the existing `--llm-timeout` / `MCP_SCANNER_LLM_TIMEOUT`.

## Usage

```bash
# Via CLI flag
mcp-scanner --stdio-timeout 180 stdio --stdio-command uvx --stdio-arg mcp-clickhouse@0.1.13

# Via environment variable (convenient for CI/CD pipelines)
export MCP_SCANNER_STDIO_TIMEOUT=180
mcp-scanner stdio --stdio-command uvx --stdio-arg mcp-clickhouse@0.1.13

# CLI flag takes precedence over env var
MCP_SCANNER_STDIO_TIMEOUT=60 mcp-scanner --stdio-timeout 300 stdio --stdio-command uvx --stdio-arg mcp-server-fetch