### PR TITLE
docs: add complete JSON output schema reference to output-formats.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ This directory contains detailed documentation for the MCP Scanner SDK.
 - **[Programmatic Usage](programmatic-usage.md)** - Examples and advanced programmatic usage
 - **[Static Scanning](static-scanning.md)** - Offline/CI-CD scanning mode for pre-generated JSON files
 - **[API Reference](api-reference.md)** - Complete REST API documentation and examples
-- **[Output Formats](output-formats.md)** - Detailed output format options and filtering
+- **[Output Formats & JSON Schema](output-formats.md)** - Output format options, filtering, and complete JSON output schema reference for CI/CD integration
 
 ## Quick Links
 

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -1,6 +1,6 @@
 # Output Formats
 
-The MCP Scanner supports multiple output formats to suit different use cases and preferences:
+The MCP Scanner supports multiple output formats to suit different use cases and preferences.
 
 ## Available Formats
 
@@ -12,29 +12,418 @@ The MCP Scanner supports multiple output formats to suit different use cases and
 - **`by_severity`**: Results grouped by severity level (HIGH, MEDIUM, LOW, UNKNOWN)
 - **`table`**: Tabular format for easy reading
 
+## JSON Output Flags: `--format raw` vs `--raw`
+
+There are two ways to get JSON output, and they produce different structures:
+
+| Flag | Envelope | Use case |
+|------|----------|----------|
+| `--format raw` | Wrapped in `{ "server_url", "scan_results", "requested_analyzers" }` | CI/CD pipelines, structured processing |
+| `--raw` / `-r` | Bare array of scan result objects (no envelope) | Quick inspection, piping to `jq` |
+
+```bash
+# Envelope JSON (recommended for CI/CD)
+mcp-scanner --format raw remote --server-url https://example.com/mcp
+
+# Bare JSON array
+mcp-scanner --raw remote --server-url https://example.com/mcp
+```
+
+---
+
+## JSON Output Schema Reference
+
+This section documents the complete JSON structure produced by `--format raw`, field by field. This is the recommended format for CI/CD pipelines and programmatic integrations.
+
+### Top-Level Envelope
+
+```json
+{
+  "server_url": "string",
+  "scan_results": [ ... ],
+  "requested_analyzers": [ ... ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `server_url` | `string` | Label identifying the scan target. Varies by mode (see [Mode-Specific Variations](#mode-specific-variations)). |
+| `scan_results` | `array` | List of per-item result objects (tools, prompts, resources). |
+| `requested_analyzers` | `array<string>` | Analyzers that were requested for this scan. Values: `"api"`, `"yara"`, `"llm"`, `"behavioral"`, `"virustotal"`, `"readiness"`. |
+
+### Scan Result Object
+
+Each element in `scan_results` has these common fields plus type-specific fields:
+
+```json
+{
+  "status": "completed",
+  "is_safe": false,
+  "item_type": "tool",
+  "findings": { ... },
+  "tool_name": "execute_command",
+  "tool_description": "Execute shell commands",
+  "server_name": "my-server",
+  "server_source": "/path/to/config.json"
+}
+```
+
+#### Common Fields (always present)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | `string` | Scan status. Typically `"completed"`. |
+| `is_safe` | `boolean` | `true` if no threats were detected, `false` otherwise. |
+| `findings` | `object` | Per-analyzer findings (see [Analyzer Findings Object](#analyzer-findings-object)). Empty `{}` when safe. |
+
+#### Type-Specific Fields
+
+The `item_type` field indicates the scanned item type, and determines which additional fields are present:
+
+| `item_type` | Additional Fields | Description |
+|-------------|-------------------|-------------|
+| `"tool"` | `tool_name`, `tool_description` | MCP tool definition |
+| `"prompt"` | `prompt_name`, `prompt_description` | MCP prompt template |
+| `"resource"` | `resource_uri`, `resource_name`, `resource_mime_type` | MCP resource |
+
+#### Optional Fields (present when applicable)
+
+| Field | Type | When Present | Description |
+|-------|------|--------------|-------------|
+| `server_name` | `string` | Config-based scans | Name of the server from the MCP config file |
+| `server_source` | `string` | Config-based scans | Path to the config file that defined this server |
+
+### Analyzer Findings Object
+
+The `findings` object is keyed by analyzer name in the format `{analyzer}_analyzer`:
+
+```json
+{
+  "findings": {
+    "yara_analyzer": { ... },
+    "llm_analyzer": { ... },
+    "api_analyzer": { ... }
+  }
+}
+```
+
+Possible keys: `api_analyzer`, `yara_analyzer`, `llm_analyzer`, `virustotal_analyzer`, `behavioral_analyzer`, `readiness_analyzer`, `prompt_defense_analyzer`.
+
+Each analyzer entry has this structure:
+
+```json
+{
+  "severity": "HIGH",
+  "threat_names": ["CODE EXECUTION", "PROMPT INJECTION"],
+  "threat_summary": "Detected 2 threats: code execution, prompt injection",
+  "total_findings": 2,
+  "mcp_taxonomies": [ ... ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `severity` | `string` | Rolled-up severity: `"HIGH"`, `"MEDIUM"`, `"LOW"`, or `"SAFE"`. Highest severity across all findings for this analyzer wins. |
+| `threat_names` | `array<string>` | List of distinct threat types detected (e.g., `"PROMPT INJECTION"`, `"CODE EXECUTION"`, `"DATA EXFILTRATION"`). |
+| `threat_summary` | `string` | Human-readable summary. Either the analyzer's own summary or auto-generated from `threat_names`. `"No threats detected"` when safe. |
+| `total_findings` | `integer` | Number of individual findings from this analyzer. `0` when safe. |
+| `mcp_taxonomies` | `array<object>` | List of unique MCP taxonomy entries (see below). Only present when findings have taxonomy mappings. |
+
+#### Severity Rollup Logic
+
+The `severity` field is the **maximum** severity across all findings for that analyzer:
+
+```
+HIGH > MEDIUM > LOW > SAFE
+```
+
+An analyzer with no findings has `severity: "SAFE"`.
+
+### MCP Taxonomy Object
+
+Each entry in `mcp_taxonomies` maps a detected threat to the standardized MCP threat taxonomy:
+
+```json
+{
+  "scanner_category": "CODE EXECUTION",
+  "aitech": "AITech-9.1",
+  "aitech_name": "Model or Agentic System Manipulation",
+  "aisubtech": "AISubtech-9.1.1",
+  "aisubtech_name": "Code Execution",
+  "description": "Autonomously generating, interpreting, or executing code..."
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `scanner_category` | `string` | The scanner's threat category name (matches values in `threat_names`). |
+| `aitech` | `string` | AITech technique ID (e.g., `AITech-1.1`, `AITech-9.1`, `AITech-12.1`). |
+| `aitech_name` | `string` | Human-readable technique name. |
+| `aisubtech` | `string` | AISubtech sub-technique ID (e.g., `AISubtech-1.1.1`). |
+| `aisubtech_name` | `string` | Human-readable sub-technique name. |
+| `description` | `string` | Detailed description of the threat. |
+
+Taxonomies are **deduplicated** per analyzer — each unique `(aitech, aisubtech)` pair appears at most once.
+
+For the full taxonomy reference, see [MCP Threats Taxonomy](mcp-threats-taxonomy.md).
+
+### Complete Example
+
+```json
+{
+  "server_url": "https://mcp-server.example.com/mcp",
+  "scan_results": [
+    {
+      "status": "completed",
+      "is_safe": false,
+      "tool_name": "execute_command",
+      "tool_description": "Execute arbitrary shell commands on the host system",
+      "item_type": "tool",
+      "findings": {
+        "yara_analyzer": {
+          "severity": "HIGH",
+          "threat_names": ["CODE EXECUTION"],
+          "threat_summary": "Detected 1 threat: code execution",
+          "total_findings": 1,
+          "mcp_taxonomies": [
+            {
+              "scanner_category": "CODE EXECUTION",
+              "aitech": "AITech-9.1",
+              "aitech_name": "Model or Agentic System Manipulation",
+              "aisubtech": "AISubtech-9.1.1",
+              "aisubtech_name": "Code Execution",
+              "description": "Autonomously generating, interpreting, or executing code, leading to unsolicited or unauthorized code execution."
+            }
+          ]
+        },
+        "llm_analyzer": {
+          "severity": "HIGH",
+          "threat_names": ["PROMPT INJECTION", "DATA EXFILTRATION"],
+          "threat_summary": "Detected 2 threats: prompt injection, data exfiltration",
+          "total_findings": 2,
+          "mcp_taxonomies": [
+            {
+              "scanner_category": "PROMPT INJECTION",
+              "aitech": "AITech-1.1",
+              "aitech_name": "Direct Prompt Injection",
+              "aisubtech": "AISubtech-1.1.1",
+              "aisubtech_name": "Instruction Manipulation (Direct Prompt Injection)",
+              "description": "Explicit attempts to override, replace, or modify the model's system instructions."
+            },
+            {
+              "scanner_category": "DATA EXFILTRATION",
+              "aitech": "AITech-8.2",
+              "aitech_name": "Data Exfiltration / Exposure",
+              "aisubtech": "AISubtech-8.2.3",
+              "aisubtech_name": "Data Exfiltration via Agent Tooling",
+              "description": "Unauthorized exposure or exfiltration of sensitive information through agent tools."
+            }
+          ]
+        }
+      }
+    },
+    {
+      "status": "completed",
+      "is_safe": true,
+      "tool_name": "calculator",
+      "tool_description": "Perform basic arithmetic",
+      "item_type": "tool",
+      "findings": {
+        "yara_analyzer": {
+          "severity": "SAFE",
+          "threat_names": [],
+          "threat_summary": "No threats detected",
+          "total_findings": 0
+        },
+        "llm_analyzer": {
+          "severity": "SAFE",
+          "threat_names": [],
+          "threat_summary": "No threats detected",
+          "total_findings": 0
+        }
+      }
+    },
+    {
+      "status": "completed",
+      "is_safe": false,
+      "prompt_name": "system_override",
+      "prompt_description": "A prompt template that attempts system manipulation",
+      "item_type": "prompt",
+      "findings": {
+        "llm_analyzer": {
+          "severity": "MEDIUM",
+          "threat_names": ["PROMPT INJECTION"],
+          "threat_summary": "Prompt injection attempt detected",
+          "total_findings": 1,
+          "mcp_taxonomies": [
+            {
+              "scanner_category": "PROMPT INJECTION",
+              "aitech": "AITech-1.1",
+              "aitech_name": "Direct Prompt Injection",
+              "aisubtech": "AISubtech-1.1.1",
+              "aisubtech_name": "Instruction Manipulation (Direct Prompt Injection)",
+              "description": "Explicit attempts to override, replace, or modify the model's system instructions."
+            }
+          ]
+        }
+      }
+    },
+    {
+      "status": "completed",
+      "is_safe": true,
+      "resource_uri": "file://data/report.csv",
+      "resource_name": "report.csv",
+      "resource_mime_type": "text/csv",
+      "item_type": "resource",
+      "findings": {}
+    }
+  ],
+  "requested_analyzers": ["yara", "llm"]
+}
+```
+
+---
+
+## Mode-Specific Variations
+
+The `server_url` field and output structure vary by scan mode:
+
+| Mode | `server_url` value | Additional fields on results |
+|------|-------------------|------------------------------|
+| `remote` | The server URL (e.g., `https://mcp.example.com/mcp`) | — |
+| `stdio` | `stdio:<command> <args>` (e.g., `stdio:uvx mcp-server-fetch`) | — |
+| `config` | The config file path (e.g., `/path/to/mcp_config.json`) | `server_name`, `server_source` |
+| `known-configs` | `well-known-configs` | `server_name`, `server_source` |
+| `static` | — (uses `--format raw` envelope) | — |
+
+### `known-configs` with `--raw`
+
+When using `--raw` with `known-configs`, the output is a map of config paths to result arrays instead of the standard envelope:
+
+```json
+{
+  "/Users/me/.cursor/mcp.json": [
+    { "status": "completed", "is_safe": true, ... }
+  ],
+  "/Users/me/.config/claude/claude_desktop_config.json": [
+    { "status": "completed", "is_safe": false, ... }
+  ]
+}
+```
+
+---
+
+## CI/CD Integration Examples
+
+### Count unsafe tools
+
+```bash
+UNSAFE=$(mcp-scanner --format raw --analyzers yara \
+  stdio --stdio-command uvx --stdio-arg mcp-server-fetch \
+  | jq '[.scan_results[] | select(.is_safe == false)] | length')
+
+if [ "$UNSAFE" -gt 0 ]; then
+  echo "Found $UNSAFE unsafe tools"
+  exit 1
+fi
+```
+
+### Extract high-severity findings
+
+```bash
+mcp-scanner --format raw --analyzers yara,llm \
+  remote --server-url https://mcp.example.com/mcp \
+  | jq '.scan_results[] | select(.is_safe == false) | {
+    name: .tool_name,
+    findings: [.findings | to_entries[] | select(.value.severity == "HIGH") | {
+      analyzer: .key,
+      threats: .value.threat_names,
+      summary: .value.threat_summary
+    }]
+  }'
+```
+
+### Check against an allowlist
+
+```bash
+RESULTS=$(mcp-scanner --format raw --analyzers yara \
+  stdio --stdio-command uvx --stdio-arg my-mcp-server)
+
+echo "$RESULTS" | jq -r '.scan_results[] | select(.is_safe == false) | .tool_name' | while read tool; do
+  if ! grep -q "^$tool$" allowlist.txt; then
+    echo "BLOCKED: $tool is not in the allowlist"
+    exit 1
+  fi
+done
+```
+
+### Generate a summary report
+
+```bash
+mcp-scanner --format raw --analyzers yara,llm \
+  remote --server-url https://mcp.example.com/mcp \
+  | jq '{
+    target: .server_url,
+    analyzers: .requested_analyzers,
+    total_items: (.scan_results | length),
+    safe: [.scan_results[] | select(.is_safe)] | length,
+    unsafe: [.scan_results[] | select(.is_safe == false)] | length,
+    high_severity: [.scan_results[].findings | to_entries[] | select(.value.severity == "HIGH")] | length,
+    all_threats: [.scan_results[].findings | to_entries[] | .value.threat_names[]?] | unique
+  }'
+```
+
+---
+
+## Statistics (`--stats`)
+
+The `--stats` flag prints scan statistics to the terminal alongside the formatted output. Statistics are displayed as human-readable text and are **not** included in the JSON output.
+
+```bash
+mcp-scanner --stats remote --server-url https://mcp.example.com/mcp
+```
+
+```
+Scan Statistics:
+  Total items scanned: 5
+  Safe: 3
+  Unsafe: 2
+  Severity breakdown:
+    HIGH: 2
+    MEDIUM: 1
+    LOW: 0
+    UNKNOWN: 0
+    SAFE: 3
+  Analyzer breakdown:
+    yara_analyzer: 5 scanned, 2 with findings
+    llm_analyzer: 5 scanned, 1 with findings
+```
+
+---
+
 ## Format Examples
 
 ### Summary Format
 ```bash
- mcp-scanner --server-url http://127.0.0.1:8001/sse --format summary
+mcp-scanner --format summary remote --server-url http://127.0.0.1:8001/sse
 ```
 Shows a concise overview with tool names, overall status, and highest severity findings.
 
 ### Detailed Format
 ```bash
-mcp-scanner --server-url http://127.0.0.1:8001/sse --format detailed
+mcp-scanner --format detailed remote --server-url http://127.0.0.1:8001/sse
 ```
-Provides comprehensive output with full finding details, including hierarchical MCP taxonomy information for all analyzers. Shows multiple taxonomies when a tool matches different threat types.
+Provides comprehensive output with full finding details, including hierarchical MCP taxonomy information for all analyzers.
 
 ### By Severity Format
 ```bash
-mcp-scanner --server-url http://127.0.0.1:8001/sse --format by_severity
+mcp-scanner --format by_severity remote --server-url http://127.0.0.1:8001/sse
 ```
 Groups all findings by severity level, making it easy to prioritize security issues.
 
 ### Table Format
 ```bash
-mcp-scanner --server-url http://127.0.0.1:8001/sse --format table
+mcp-scanner --format table remote --server-url http://127.0.0.1:8001/sse
 ```
 Displays results in a clean tabular format with columns for tool, analyzer, severity, and findings.
 
@@ -43,10 +432,7 @@ Displays results in a clean tabular format with columns for tool, analyzer, seve
 ### Severity Filtering
 ```bash
 # Show only high severity findings
-mcp-scanner --server-url http://127.0.0.1:8001/sse --severity-filter high
-
-# Show high and medium severity findings
-mcp-scanner --server-url http://127.0.0.1:8001/sse --severity-filter high,medium
+mcp-scanner --severity-filter high remote --server-url http://127.0.0.1:8001/sse
 
 # Available severity levels: high, medium, low, unknown
 ```
@@ -54,10 +440,7 @@ mcp-scanner --server-url http://127.0.0.1:8001/sse --severity-filter high,medium
 ### Analyzer Filtering
 ```bash
 # Show only YARA analyzer results
-mcp-scanner --server-url http://127.0.0.1:8001/sse --analyzer-filter yara_analyzer
-
-# Show API and LLM analyzer results
-mcp-scanner --server-url http://127.0.0.1:8001/sse --analyzer-filter api_analyzer,llm_analyzer
+mcp-scanner --analyzer-filter yara_analyzer remote --server-url http://127.0.0.1:8001/sse
 
 # Available analyzers: api_analyzer, yara_analyzer, llm_analyzer, virustotal_analyzer, vulnerable_package_analyzer
 ```
@@ -65,13 +448,13 @@ mcp-scanner --server-url http://127.0.0.1:8001/sse --analyzer-filter api_analyze
 ### Additional Options
 ```bash
 # Hide tools with no security findings
-mcp-scanner --server-url http://127.0.0.1:8001/sse --hide-safe
+mcp-scanner --hide-safe remote --server-url http://127.0.0.1:8001/sse
 
-# Show scan statistics (total tools, unsafe tools, etc.)
-mcp-scanner --server-url http://127.0.0.1:8001/sse --stats
+# Show scan statistics
+mcp-scanner --stats remote --server-url http://127.0.0.1:8001/sse
 
 # Combine multiple options
-mcp-scanner --server-url http://127.0.0.1:8001/sse --format by_severity --severity-filter high,medium --stats
+mcp-scanner --format by_severity --severity-filter high,medium --stats remote --server-url http://127.0.0.1:8001/sse
 ```
 
 ## Example Output
@@ -141,6 +524,8 @@ mcp-scanner --server-url http://127.0.0.1:8001/sse --format by_severity --severi
 - **Prompts**: `prompt_name`, `prompt_description`
 - **Resources**: `resource_uri`, `resource_name`, `resource_mime_type`
 - **Vulnerable Packages**: `package_name`, `vulnerability_description` (uses `mcp_server_repository` instead of `server_url` at the top level)
+
+## Human-Readable Output Examples
 
 ### Detailed Format Example
 ```


### PR DESCRIPTION
Documents the full field-by-field JSON schema for --format raw output, including the top-level envelope, per-item result objects, analyzer findings structure, MCP taxonomy objects, mode-specific variations, and CI/CD integration examples with jq.
