### PR TITLE
Fix/logging and stderr control

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ mcp-scanner --stdio-command uvx --stdio-arg=--from --stdio-arg=mcp-server-fetch 
 # Remote server (deepwiki example)
 mcp-scanner --server-url https://mcp.deepwiki.com/mcp --analyzers yara --format summary
 
+# Suppress all output below ERROR (useful in CI/CD)
+mcp-scanner --log-level error --analyzers yara --format raw --server-url https://mcp.deepwiki.com/mcp
+
 # MCP Scanner as REST API
 mcp-scanner-api --host 0.0.0.0 --port 8080
 
@@ -196,10 +199,15 @@ mcp-scanner-api --host 0.0.0.0 --port 8080
 
 ```python
 import asyncio
-from mcpscanner import Config, Scanner
+import os
+from mcpscanner import Config, Scanner, set_log_level
 from mcpscanner.core.models import AnalyzerEnum
+import logging
 
 async def main():
+    # Suppress all mcpscanner logs below ERROR
+    set_log_level(logging.ERROR)
+
     # Create configuration with your API keys
     config = Config(
         api_key="your_cisco_api_key",
@@ -239,6 +247,16 @@ async def main():
     # Print resource results
     for result in resource_results:
         print(f"Resource: {result.resource_name}, Safe: {result.is_safe}, Status: {result.status}")
+
+    # Scan a stdio server while suppressing its stderr output
+    from mcpscanner.core.mcp_models import StdioServer
+    server = StdioServer(command="uvx", args=["mcp-server-fetch"])
+    with open(os.devnull, "w") as devnull:
+        stdio_results = await scanner.scan_stdio_server_tools(
+            server,
+            analyzers=[AnalyzerEnum.YARA],
+            errlog=devnull
+        )
 
 # Run the scanner
 asyncio.run(main())
@@ -525,6 +543,62 @@ mcp-scanner --analyzers yara,prompt_defense --server-url http://localhost:8000/m
 ```
 
 Each missing defense maps to MCP Taxonomy codes (AITech / AISubtech) for standardized reporting.
+
+### Logging Control
+
+By default the CLI shows `WARNING`-level output (or `DEBUG` with `--verbose`). For finer control use `--log-level`:
+
+```bash
+# Show only errors (good for CI/CD)
+mcp-scanner --log-level error --analyzers yara --format raw --server-url https://mcp.deepwiki.com/mcp
+
+# Show warnings and above
+mcp-scanner --log-level warning --analyzers yara --format summary --scan-known-configs
+
+# Full debug output (equivalent to --verbose)
+mcp-scanner --log-level debug --analyzers yara --server-url https://mcp.deepwiki.com/mcp
+```
+
+`--log-level` takes precedence over `--verbose` when both are provided.
+
+#### Library Log Level (SDK)
+
+Library consumers can control the log level programmatically. Unlike
+`logging.getLogger("mcpscanner").setLevel(...)`, which does not propagate
+to child loggers, `set_log_level` updates **every** mcpscanner logger and
+handler:
+
+```python
+import logging
+from mcpscanner import set_log_level
+
+set_log_level(logging.ERROR)    # suppress everything below ERROR
+set_log_level(logging.DEBUG)    # show all debug output
+```
+
+#### Suppressing Stdio Server Stderr
+
+MCP servers launched via stdio may emit noisy output to stderr (startup
+banners, dependency logs, etc.). All stdio scan methods accept an `errlog`
+parameter to redirect or suppress this output:
+
+```python
+import os
+from mcpscanner import Scanner, Config
+from mcpscanner.core.mcp_models import StdioServer
+
+scanner = Scanner(Config())
+server = StdioServer(command="uvx", args=["mcp-server-fetch"])
+
+with open(os.devnull, "w") as devnull:
+    results = await scanner.scan_stdio_server_tools(server, errlog=devnull)
+    prompts = await scanner.scan_stdio_server_prompts(server, errlog=devnull)
+```
+
+The `errlog` parameter is supported on `scan_stdio_server_tools`,
+`scan_stdio_server_tool`, `scan_stdio_server_prompts`,
+`scan_stdio_server_prompt`, `scan_well_known_mcp_configs`, and
+`scan_mcp_config_file`.
 
 ### API Server Usage
 

--- a/mcpscanner/__init__.py
+++ b/mcpscanner/__init__.py
@@ -50,6 +50,7 @@ from .core.result import (
     ResourceScanResult,
 )
 from .core.models import AnalyzerEnum
+from .utils.logging_config import set_log_level, set_verbose_logging
 
 __all__ = [
     "Config",
@@ -77,4 +78,6 @@ __all__ = [
     "AnalyzerEnum",
     "get_scanner",
     "router",
+    "set_log_level",
+    "set_verbose_logging",
 ]

--- a/mcpscanner/cli.py
+++ b/mcpscanner/cli.py
@@ -44,7 +44,7 @@ from mcpscanner.core.report_generator import (
     SeverityFilter,
     results_to_json,
 )
-from mcpscanner.utils.logging_config import set_verbose_logging
+from mcpscanner.utils.logging_config import set_verbose_logging, set_log_level
 from mcpscanner.core.auth import Auth
 from mcpscanner.core.mcp_models import StdioServer
 from mcpscanner.core.analyzers.static_analyzer import StaticAnalyzer
@@ -1162,6 +1162,13 @@ async def main():
         "--verbose", "-v", action="store_true", help="Print verbose output"
     )
     parser.add_argument(
+        "--log-level",
+        choices=["debug", "info", "warning", "error", "critical"],
+        default=None,
+        help="Set log level for the mcpscanner library (overrides --verbose). "
+        "Useful for suppressing noisy output in CI/CD pipelines.",
+    )
+    parser.add_argument(
         "--detailed", "-d", action="store_true", help="Show detailed results"
     )
     parser.add_argument(
@@ -1305,14 +1312,21 @@ async def main():
                 "Usage: mcp-scanner --source-path FILE --analyzers behavioral"
             )
 
-    if args.verbose:
+    if args.log_level:
+        effective_level = getattr(logging, args.log_level.upper())
+        logging.basicConfig(
+            level=effective_level,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            stream=sys.stdout,
+        )
+        set_log_level(effective_level)
+    elif args.verbose:
         logging.basicConfig(
             level=logging.DEBUG,
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
             stream=sys.stdout,
         )
-        logging.getLogger("mcpscanner").setLevel(logging.DEBUG)
-        set_verbose_logging(True)
+        set_log_level(logging.DEBUG)
         logger.info("Verbose output enabled - detailed analyzer logs will be shown")
     else:
         logging.basicConfig(
@@ -1320,8 +1334,7 @@ async def main():
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
             stream=sys.stdout,
         )
-        logging.getLogger("mcpscanner").setLevel(logging.WARNING)
-        set_verbose_logging(False)
+        set_log_level(logging.WARNING)
 
     if args.api_key:
         os.environ["MCP_SCANNER_API_KEY"] = args.api_key

--- a/mcpscanner/core/scanner.py
+++ b/mcpscanner/core/scanner.py
@@ -1441,11 +1441,16 @@ class Scanner:
         analyzers: Optional[List[AnalyzerEnum]] = None,
         auth: Optional[Auth] = None,
         expand_vars_default: Optional[str] = None,
+        errlog: Any = None,
     ) -> Dict[str, List[ToolScanResult]]:
         """Scan all well-known MCP configuration files and their servers.
 
         Args:
             analyzers (Optional[List[AnalyzerEnum]]): List of analyzers to run. Defaults to all analyzers.
+            auth (Optional[Auth]): Authentication configuration for remote servers.
+            expand_vars_default (Optional[str]): Default variable expansion mode.
+            errlog: Optional file-like object for stderr redirection of stdio servers.
+                    Pass ``open(os.devnull, "w")`` to suppress server stderr.
 
         Returns:
             Dict[str, List[ToolScanResult]]: Dictionary mapping config file paths to scan results.
@@ -1486,7 +1491,7 @@ class Scanner:
                         # Scan stdio server with timeout and error recovery
                         try:
                             results = await self.scan_stdio_server_tools(
-                                server_config, analyzers
+                                server_config, analyzers, errlog=errlog
                             )
                             # Add server name and source to each result
                             for result in results:
@@ -1546,12 +1551,17 @@ class Scanner:
         analyzers: Optional[List[AnalyzerEnum]] = None,
         auth: Optional[Auth] = None,
         expand_vars_default: Optional[str] = None,
+        errlog: Any = None,
     ) -> List[ToolScanResult]:
         """Scan all servers in a specific MCP configuration file.
 
         Args:
             config_path (str): Path to the MCP configuration file.
             analyzers (Optional[List[AnalyzerEnum]]): List of analyzers to run. Defaults to all analyzers.
+            auth (Optional[Auth]): Authentication configuration for remote servers.
+            expand_vars_default (Optional[str]): Default variable expansion mode.
+            errlog: Optional file-like object for stderr redirection of stdio servers.
+                    Pass ``open(os.devnull, "w")`` to suppress server stderr.
 
         Returns:
             List[ToolScanResult]: The results of scanning all servers in the config file.
@@ -1591,7 +1601,7 @@ class Scanner:
                     # Scan stdio server with timeout and error recovery
                     try:
                         results = await self.scan_stdio_server_tools(
-                            server_config, analyzers
+                            server_config, analyzers, errlog=errlog
                         )
                         # Add server name and source to each result
                         for result in results:
@@ -1895,6 +1905,7 @@ class Scanner:
         server_config: StdioServer,
         analyzers: Optional[List[AnalyzerEnum]] = None,
         timeout: Optional[int] = None,
+        errlog: Any = None,
     ) -> List[PromptScanResult]:
         """Scan prompts from a stdio MCP server.
 
@@ -1902,6 +1913,8 @@ class Scanner:
             server_config: The stdio server configuration
             analyzers: List of analyzers to use (defaults to API and LLM)
             timeout: Connection timeout in seconds
+            errlog: Optional file-like object for stderr redirection.
+                    Pass ``open(os.devnull, "w")`` to suppress server stderr.
 
         Returns:
             List of prompt scan results
@@ -1923,7 +1936,7 @@ class Scanner:
             async def connect_and_scan():
                 nonlocal client_context, session
                 client_context, session = await self._get_stdio_session(
-                    server_config, timeout
+                    server_config, timeout, errlog
                 )
 
                 # List all prompts
@@ -1965,6 +1978,7 @@ class Scanner:
         prompt_name: str,
         analyzers: Optional[List[AnalyzerEnum]] = None,
         timeout: Optional[int] = None,
+        errlog: Any = None,
     ) -> PromptScanResult:
         """Scan a specific prompt on a stdio MCP server.
 
@@ -1973,6 +1987,8 @@ class Scanner:
             prompt_name (str): The name of the prompt to scan.
             analyzers (Optional[List[AnalyzerEnum]]): List of analyzers to run. Defaults to API and LLM.
             timeout (Optional[int]): Timeout for the connection.
+            errlog: Optional file-like object for stderr redirection.
+                    Pass ``open(os.devnull, "w")`` to suppress server stderr.
 
         Returns:
             PromptScanResult: The result of the scan.
@@ -1994,7 +2010,7 @@ class Scanner:
         session = None
         try:
             client_context, session = await self._get_stdio_session(
-                server_config, timeout
+                server_config, timeout, errlog
             )
 
             # List all prompts and find the target prompt

--- a/mcpscanner/utils/__init__.py
+++ b/mcpscanner/utils/__init__.py
@@ -17,6 +17,6 @@
 """Utilities module for MCP Scanner."""
 
 from .di_container import DIContainer
-from .logging_config import setup_logger
+from .logging_config import setup_logger, set_log_level, set_verbose_logging
 
-__all__ = ["DIContainer", "setup_logger"]
+__all__ = ["DIContainer", "setup_logger", "set_log_level", "set_verbose_logging"]

--- a/mcpscanner/utils/logging_config.py
+++ b/mcpscanner/utils/logging_config.py
@@ -88,6 +88,41 @@ def get_logger(name: str, level: Optional[str] = None) -> logging.Logger:
     return setup_logger(name, level)
 
 
+def set_log_level(level: int) -> None:
+    """
+    Set the log level for the entire mcpscanner library.
+
+    This updates the ``mcpscanner`` root logger **and** every child logger
+    (plus their handlers), so it works regardless of whether child loggers
+    were created with explicit levels or ``propagate = False``.
+
+    Can be called at any time — it affects loggers that already exist as
+    well as new ones created later (via the root logger level check in
+    ``setup_logger``).
+
+    Args:
+        level: A ``logging`` level constant, e.g. ``logging.ERROR``,
+               ``logging.WARNING``, ``logging.DEBUG``.
+
+    Example::
+
+        import logging
+        from mcpscanner.utils.logging_config import set_log_level
+
+        set_log_level(logging.ERROR)   # suppress everything below ERROR
+        set_log_level(logging.DEBUG)   # show all debug output
+    """
+    root_logger = logging.getLogger("mcpscanner")
+    root_logger.setLevel(level)
+
+    for name in list(logging.Logger.manager.loggerDict.keys()):
+        if name.startswith("mcpscanner"):
+            child = logging.getLogger(name)
+            child.setLevel(level)
+            for handler in child.handlers:
+                handler.setLevel(level)
+
+
 def set_verbose_logging(verbose: bool = False) -> None:
     """
     Enable or disable verbose logging for all mcpscanner loggers.
@@ -95,17 +130,4 @@ def set_verbose_logging(verbose: bool = False) -> None:
     Args:
         verbose: If True, set all existing mcpscanner loggers to DEBUG level
     """
-    target_level = logging.DEBUG if verbose else logging.INFO
-
-    # Set the root mcpscanner logger level
-    root_logger = logging.getLogger("mcpscanner")
-    root_logger.setLevel(target_level)
-
-    # Update all existing mcpscanner loggers
-    for name in list(logging.Logger.manager.loggerDict.keys()):
-        if name.startswith("mcpscanner"):
-            logger = logging.getLogger(name)
-            logger.setLevel(target_level)
-            # Update handler levels too
-            for handler in logger.handlers:
-                handler.setLevel(target_level)
+    set_log_level(logging.DEBUG if verbose else logging.INFO)

--- a/mcpscanner/utils/logging_config.py
+++ b/mcpscanner/utils/logging_config.py
@@ -47,11 +47,9 @@ def setup_logger(
     if logger.handlers:
         return logger
 
-    # Check if mcpscanner root logger has been configured for debug
     mcpscanner_root = logging.getLogger("mcpscanner")
-    if mcpscanner_root.level == logging.DEBUG and name.startswith("mcpscanner"):
-        # Use DEBUG level if the root mcpscanner logger is set to DEBUG
-        logger.setLevel(logging.DEBUG)
+    if mcpscanner_root.level != logging.NOTSET and name.startswith("mcpscanner"):
+        logger.setLevel(mcpscanner_root.level)
     elif level:
         logger.setLevel(getattr(logging, level.upper()))
     else:

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,167 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for logging configuration and set_log_level."""
+
+import logging
+
+import pytest
+
+from mcpscanner.utils.logging_config import (
+    get_logger,
+    set_log_level,
+    set_verbose_logging,
+    setup_logger,
+)
+
+
+def _cleanup_loggers(*names: str):
+    """Remove handlers and reset levels on test loggers."""
+    for name in names:
+        lg = logging.getLogger(name)
+        lg.handlers.clear()
+        lg.setLevel(logging.NOTSET)
+        lg.propagate = True
+
+
+class TestSetLogLevel:
+    """Tests for the set_log_level function."""
+
+    def setup_method(self):
+        self.child_names = [
+            "mcpscanner.test_child_a",
+            "mcpscanner.test_child_b",
+            "mcpscanner.test_child_a.deep",
+        ]
+        for name in self.child_names:
+            _cleanup_loggers(name)
+        _cleanup_loggers("mcpscanner")
+
+    def teardown_method(self):
+        for name in self.child_names:
+            _cleanup_loggers(name)
+
+    def test_set_log_level_affects_root_mcpscanner_logger(self):
+        root = logging.getLogger("mcpscanner")
+        set_log_level(logging.ERROR)
+        assert root.level == logging.ERROR
+
+    def test_set_log_level_affects_existing_child_loggers(self):
+        child_a = get_logger("mcpscanner.test_child_a")
+        child_b = get_logger("mcpscanner.test_child_b")
+        assert child_a.level == logging.INFO
+        assert child_b.level == logging.INFO
+
+        set_log_level(logging.ERROR)
+
+        assert child_a.level == logging.ERROR
+        assert child_b.level == logging.ERROR
+
+    def test_set_log_level_updates_handler_levels(self):
+        child = get_logger("mcpscanner.test_child_a")
+        assert child.handlers
+        for h in child.handlers:
+            assert h.level == logging.INFO
+
+        set_log_level(logging.CRITICAL)
+
+        for h in child.handlers:
+            assert h.level == logging.CRITICAL
+
+    def test_set_log_level_suppresses_info_messages(self, capfd):
+        child = get_logger("mcpscanner.test_child_a")
+        set_log_level(logging.ERROR)
+
+        child.info("this should be suppressed")
+        child.warning("this should also be suppressed")
+        child.error("this should appear")
+
+        captured = capfd.readouterr()
+        assert "this should be suppressed" not in captured.out
+        assert "this should also be suppressed" not in captured.out
+        assert "this should appear" in captured.out
+
+    def test_set_log_level_to_debug_shows_all(self, capfd):
+        child = get_logger("mcpscanner.test_child_b")
+        set_log_level(logging.DEBUG)
+
+        child.debug("debug message")
+        child.info("info message")
+
+        captured = capfd.readouterr()
+        assert "debug message" in captured.out
+        assert "info message" in captured.out
+
+    def test_set_log_level_deep_child(self):
+        deep = get_logger("mcpscanner.test_child_a.deep")
+        set_log_level(logging.WARNING)
+        assert deep.level == logging.WARNING
+
+    def test_set_log_level_does_not_affect_non_mcpscanner(self):
+        other = logging.getLogger("some_other_library")
+        original_level = other.level
+        set_log_level(logging.CRITICAL)
+        assert other.level == original_level
+
+    def test_set_log_level_multiple_calls(self):
+        child = get_logger("mcpscanner.test_child_a")
+
+        set_log_level(logging.ERROR)
+        assert child.level == logging.ERROR
+
+        set_log_level(logging.DEBUG)
+        assert child.level == logging.DEBUG
+
+        set_log_level(logging.WARNING)
+        assert child.level == logging.WARNING
+
+
+class TestSetVerboseLogging:
+    """Tests for set_verbose_logging (delegates to set_log_level)."""
+
+    def setup_method(self):
+        self.child_name = "mcpscanner.test_verbose"
+        _cleanup_loggers(self.child_name, "mcpscanner")
+
+    def teardown_method(self):
+        _cleanup_loggers(self.child_name)
+
+    def test_verbose_true_sets_debug(self):
+        child = get_logger(self.child_name)
+        set_verbose_logging(True)
+        assert child.level == logging.DEBUG
+
+    def test_verbose_false_sets_info(self):
+        child = get_logger(self.child_name)
+        set_verbose_logging(True)
+        set_verbose_logging(False)
+        assert child.level == logging.INFO
+
+
+class TestPublicImports:
+    """Verify set_log_level and set_verbose_logging are importable from top-level."""
+
+    def test_import_from_mcpscanner(self):
+        from mcpscanner import set_log_level as sl, set_verbose_logging as sv
+
+        assert callable(sl)
+        assert callable(sv)
+
+    def test_import_from_utils(self):
+        from mcpscanner.utils import set_log_level as sl, set_verbose_logging as sv
+
+        assert callable(sl)
+        assert callable(sv)

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -128,6 +128,26 @@ class TestSetLogLevel:
         set_log_level(logging.WARNING)
         assert child.level == logging.WARNING
 
+    def test_new_logger_inherits_root_level(self):
+        """Loggers created after set_log_level() should inherit the root level."""
+        set_log_level(logging.ERROR)
+
+        new_name = "mcpscanner.test_child_after_set"
+        _cleanup_loggers(new_name)
+        new_child = setup_logger(new_name)
+        assert new_child.level == logging.ERROR
+        _cleanup_loggers(new_name)
+
+    def test_new_logger_inherits_warning_level(self):
+        """Covers all levels, not just DEBUG — the original bug."""
+        set_log_level(logging.WARNING)
+
+        new_name = "mcpscanner.test_child_warn"
+        _cleanup_loggers(new_name)
+        new_child = setup_logger(new_name)
+        assert new_child.level == logging.WARNING
+        _cleanup_loggers(new_name)
+
 
 class TestSetVerboseLogging:
     """Tests for set_verbose_logging (delegates to set_log_level)."""


### PR DESCRIPTION
## Summary

- Add `set_log_level(level)` — a public API that applies a given log level across **all** mcpscanner loggers and their handlers, fixing the issue where `logging.getLogger("mcpscanner").setLevel()` had no effect.
- Add `--log-level {debug,info,warning,error,critical}` CLI flag for fine-grained log control (overrides `--verbose`).
- Add `errlog` parameter to the four stdio scan methods that were missing it (`scan_stdio_server_prompts`, `scan_stdio_server_prompt`, `scan_well_known_mcp_configs`, `scan_mcp_config_file`), allowing callers to redirect or suppress MCP server stderr.

## Motivation

**Logging:** Library consumers have no way to suppress INFO/WARNING messages from mcpscanner internals. `logging.getLogger("mcpscanner").setLevel(logging.ERROR)` does nothing because every child logger created by `setup_logger()` sets its own explicit level (`INFO`) and has `propagate = False`, so the parent level is never consulted. The only existing function (`set_verbose_logging`) only toggles between DEBUG and INFO — it cannot set ERROR or CRITICAL.

**Stderr:** When using the Scanner API to scan stdio MCP servers, the server's stderr is always directed to `sys.stderr`, polluting the scanner's output. Some MCP servers (e.g. FastMCP-based) emit large startup banners. The `errlog` parameter already existed on `scan_stdio_server_tools` and `scan_stdio_server_tool`, but was missing from the prompt and config scan methods.

## Changes

| File | Change |
|------|--------|
| `mcpscanner/utils/logging_config.py` | Add `set_log_level(level)` that iterates all `mcpscanner.*` loggers + handlers; refactor `set_verbose_logging` to delegate to it |
| `mcpscanner/utils/__init__.py` | Export `set_log_level` and `set_verbose_logging` |
| `mcpscanner/__init__.py` | Export `set_log_level` and `set_verbose_logging` from top-level package |
| `mcpscanner/cli.py` | Add `--log-level` argument; use `set_log_level()` in logging setup; import `set_log_level` |
| `mcpscanner/core/scanner.py` | Add `errlog` param to `scan_stdio_server_prompts`, `scan_stdio_server_prompt`, `scan_well_known_mcp_configs`, `scan_mcp_config_file`; thread it through to `_get_stdio_session` and child `scan_stdio_server_tools` calls |
| `tests/test_logging_config.py` | 12 new tests covering `set_log_level` behavior, handler updates, message suppression, and public imports |
| `README.md` | Document `--log-level`, `set_log_level()` SDK usage, and `errlog` parameter |

## Usage

### CLI

```bash
# Suppress all logs below ERROR (clean CI/CD output)
mcp-scanner --log-level error --analyzers yara --format raw --server-url https://mcp.deepwiki.com/mcp

# Full debug output
mcp-scanner --log-level debug --analyzers yara --server-url https://mcp.deepwiki.com/mcp
```

### SDK — Log Level

```python
import logging
from mcpscanner import set_log_level

set_log_level(logging.ERROR)  # suppress everything below ERROR
```

### SDK — Suppress Stdio Stderr

```python
import os
from mcpscanner import Scanner, Config
from mcpscanner.core.mcp_models import StdioServer

scanner = Scanner(Config())
server = StdioServer(command="uvx", args=["mcp-server-fetch"])

with open(os.devnull, "w") as devnull:
    results = await scanner.scan_stdio_server_tools(server, errlog=devnull)
    prompts = await scanner.scan_stdio_server_prompts(server, errlog=devnull)
```

## Example Output

### `--log-level error` (clean CI/CD output)

```
=== MCP Scanner Results Summary ===

Scan Target: https://mcp.deepwiki.com/mcp
Total tools scanned: 3
Items matching filters: 3
Safe items: 3
Unsafe items: 0
```

### `--log-level debug` (full trace)

```
2026-04-09 14:23:59,590 - mcpscanner.core.analyzers.base.YARA - DEBUG - Using default YARA rules directory: rules_dir="..."
2026-04-09 14:23:59,590 - mcpscanner.core.analyzers.base.YARA - DEBUG - Found rule file: coercive_injection.yara
2026-04-09 14:23:59,608 - mcpscanner.core.analyzers.base.YARA - DEBUG - YARA rules compiled successfully
2026-04-09 14:23:59,608 - mcpscanner.core.scanner - DEBUG - Scanner initialized: active_analyzers="['YARA', 'Readiness', 'PromptDefense']"
2026-04-09 14:23:59,609 - mcpscanner.core.scanner - DEBUG - No explicit auth provided, connecting without authentication
...
=== MCP Scanner Results Summary ===
...
```

## Test Plan

- [x] 12 new unit tests in `tests/test_logging_config.py`
- [x] All 53 existing tests pass (logging + CLI + config)
- [x] Manual verification: `--log-level error` produces clean output; `--log-level debug` shows full trace
- [x] No linter errors introduced
