### PR TITLE
fix: surface safe tools in behavioral scan results

### DIFF
--- a/mcpscanner/cli.py
+++ b/mcpscanner/cli.py
@@ -176,90 +176,160 @@ def _build_config(
     return Config(**config_params)
 
 
-async def _run_behavioral_analyzer_on_source(source_path: str) -> List[Dict[str, Any]]:
-    """Run behavioral analyzer on source code and format results.
+def _build_behavioral_results(
+    analyzer: Any,
+    findings: List[Any],
+    source_path: str,
+) -> List[Dict[str, Any]]:
+    """Build tool-style result dicts for every function analyzed by the behavioral analyzer.
+
+    The behavioral analyzer only emits a ``SecurityFinding`` when it detects a
+    docstring/behavior mismatch, which means functions that come back clean
+    would otherwise be invisible in the scan output. This helper uses
+    ``analyzer.analyzed_functions`` to ensure the returned list contains one
+    entry per tool discovered during the scan — safe tools (no findings) and
+    unsafe tools (with findings) alike.
 
     Args:
-        source_path: Path to Python file or directory to analyze
+        analyzer: A ``BehavioralCodeAnalyzer`` instance that has just completed
+            an ``analyze()`` call. Its ``analyzed_functions`` attribute is used
+            to enumerate every function the scan visited.
+        findings: The list of ``SecurityFinding`` objects returned by
+            ``analyzer.analyze(...)``.
+        source_path: The original path that was scanned (file or directory).
 
     Returns:
-        List of formatted result dictionaries
+        A list of result dictionaries matching the structure produced elsewhere
+        for tool scan results. Each dictionary exposes ``tool_name``,
+        ``tool_description``, ``status``, ``is_safe`` and ``findings``.
     """
-    from mcpscanner.core.analyzers.behavioral import BehavioralCodeAnalyzer
-
-    cfg = _build_config([AnalyzerEnum.BEHAVIORAL])
-    analyzer = BehavioralCodeAnalyzer(cfg)
-
-    # Analyze the source file
-    findings = await analyzer.analyze(source_path, context={"file_path": source_path})
-
-    # Format results to match Scanner output structure
-    findings_by_function = {}
+    # Group findings by (source_file, function_name) so multi-file scans with
+    # identically named functions don't collide on a single result entry.
+    findings_by_key: Dict[tuple, List[Any]] = {}
     for finding in findings:
-        func_name = (
-            finding.details.get("function_name", "unknown")
-            if finding.details
-            else "unknown"
-        )
+        details = finding.details or {}
+        func_name = details.get("function_name", "unknown")
+        src_file = details.get("source_file", source_path)
+        findings_by_key.setdefault((src_file, func_name), []).append(finding)
 
-        if func_name not in findings_by_function:
-            findings_by_function[func_name] = []
-        findings_by_function[func_name].append(finding)
+    severity_order = {"HIGH": 3, "MEDIUM": 2, "LOW": 1, "SAFE": 0, "UNKNOWN": 0}
+    results: List[Dict[str, Any]] = []
+    seen_keys: set = set()
 
-    # Create ToolScanResult-like structure
-    results = []
-    for func_name, func_findings in findings_by_function.items():
-        severity_order = {"HIGH": 3, "MEDIUM": 2, "LOW": 1, "SAFE": 0, "UNKNOWN": 0}
-        max_severity = max(
-            (f.severity for f in func_findings), key=lambda s: severity_order.get(s, 0)
-        )
+    # Iterate over every function the analyzer processed so that safe tools
+    # appear in the output even when no finding was produced for them.
+    analyzed_functions = getattr(analyzer, "analyzed_functions", []) or []
+    for analyzed in analyzed_functions:
+        func_name = analyzed.get("name", "unknown")
+        source_file = analyzed.get("source_file", source_path)
+        key = (source_file, func_name)
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
 
-        source_file = (
-            func_findings[0].details.get("source_file", source_path)
-            if func_findings[0].details
+        display_name = (
+            os.path.basename(source_file)
+            if source_file and source_file != source_path
             else source_path
         )
-        display_name = (
-            os.path.basename(source_file) if source_file != source_path else source_path
-        )
 
-        # Collect unique MCP taxonomies from all findings
-        mcp_taxonomies = []
-        for finding in func_findings:
-            if hasattr(finding, "mcp_taxonomy") and finding.mcp_taxonomy:
+        func_findings = findings_by_key.get(key, [])
+
+        if func_findings:
+            max_severity = max(
+                (f.severity for f in func_findings),
+                key=lambda s: severity_order.get(s, 0),
+            )
+
+            mcp_taxonomies: List[Dict[str, Any]] = []
+            for finding in func_findings:
+                taxonomy = getattr(finding, "mcp_taxonomy", None)
+                if not taxonomy:
+                    continue
                 taxonomy_key = (
-                    finding.mcp_taxonomy.get("aitech"),
-                    finding.mcp_taxonomy.get("aisubtech"),
+                    taxonomy.get("aitech"),
+                    taxonomy.get("aisubtech"),
                 )
                 existing_keys = [
                     (t.get("aitech"), t.get("aisubtech")) for t in mcp_taxonomies
                 ]
                 if taxonomy_key not in existing_keys:
-                    mcp_taxonomies.append(finding.mcp_taxonomy)
+                    mcp_taxonomies.append(taxonomy)
 
-        # Get threat/vulnerability classification from first finding
-        threat_vuln_classification = None
-        if func_findings and func_findings[0].details:
-            threat_vuln_classification = func_findings[0].details.get(
-                "threat_vulnerability_classification"
+            threat_vuln_classification = None
+            if func_findings[0].details:
+                threat_vuln_classification = func_findings[0].details.get(
+                    "threat_vulnerability_classification"
+                )
+
+            analyzer_finding: Dict[str, Any] = {
+                "severity": max_severity,
+                "threat_summary": func_findings[0].summary,
+                "threat_names": sorted(
+                    {f.threat_category for f in func_findings if f.threat_category}
+                ),
+                "total_findings": len(func_findings),
+                "source_file": source_file,
+                "mcp_taxonomies": mcp_taxonomies,
+            }
+            if threat_vuln_classification:
+                analyzer_finding["threat_vulnerability_classification"] = (
+                    threat_vuln_classification
+                )
+
+            results.append(
+                {
+                    "tool_name": func_name,
+                    "tool_description": f"MCP function from {display_name}",
+                    "status": "completed",
+                    "is_safe": False,
+                    "findings": {"behavioral_analyzer": analyzer_finding},
+                }
+            )
+        else:
+            # No mismatch detected for this tool — still surface it as a safe
+            # result so the scan output enumerates ALL tools that were found,
+            # not only the ones flagged as malicious.
+            results.append(
+                {
+                    "tool_name": func_name,
+                    "tool_description": f"MCP function from {display_name}",
+                    "status": "completed",
+                    "is_safe": True,
+                    "findings": {
+                        "behavioral_analyzer": {
+                            "severity": "SAFE",
+                            "threat_summary": "No behavioral mismatches detected",
+                            "threat_names": [],
+                            "total_findings": 0,
+                            "source_file": source_file,
+                            "mcp_taxonomies": [],
+                        }
+                    },
+                }
             )
 
-        analyzer_finding = {
-            "severity": max_severity,
-            "threat_summary": func_findings[0].summary,
-            "threat_names": list(
-                set([f.threat_category for f in func_findings])
-            ),  # Deduplicate
-            "total_findings": len(func_findings),
-            "source_file": source_file,
-            "mcp_taxonomies": mcp_taxonomies,
-        }
+    # Surface any findings that didn't match a recorded analyzed function
+    # (defensive: should be rare, but guarantees no finding is dropped).
+    for (src_file, func_name), func_findings in findings_by_key.items():
+        if (src_file, func_name) in seen_keys:
+            continue
+        seen_keys.add((src_file, func_name))
 
-        # Add threat/vulnerability classification if available
-        if threat_vuln_classification:
-            analyzer_finding["threat_vulnerability_classification"] = (
-                threat_vuln_classification
-            )
+        max_severity = max(
+            (f.severity for f in func_findings),
+            key=lambda s: severity_order.get(s, 0),
+        )
+        display_name = (
+            os.path.basename(src_file)
+            if src_file and src_file != source_path
+            else source_path
+        )
+        mcp_taxonomies = []
+        for finding in func_findings:
+            taxonomy = getattr(finding, "mcp_taxonomy", None)
+            if taxonomy and taxonomy not in mcp_taxonomies:
+                mcp_taxonomies.append(taxonomy)
 
         results.append(
             {
@@ -267,12 +337,23 @@ async def _run_behavioral_analyzer_on_source(source_path: str) -> List[Dict[str,
                 "tool_description": f"MCP function from {display_name}",
                 "status": "completed",
                 "is_safe": False,
-                "findings": {"behavioral_analyzer": analyzer_finding},
+                "findings": {
+                    "behavioral_analyzer": {
+                        "severity": max_severity,
+                        "threat_summary": func_findings[0].summary,
+                        "threat_names": sorted(
+                            {f.threat_category for f in func_findings if f.threat_category}
+                        ),
+                        "total_findings": len(func_findings),
+                        "source_file": src_file,
+                        "mcp_taxonomies": mcp_taxonomies,
+                    }
+                },
             }
         )
 
     if not results:
-        results = [
+        results.append(
             {
                 "tool_name": "No MCP functions found",
                 "tool_description": f"No @mcp.tool() decorators found in {source_path}",
@@ -280,9 +361,30 @@ async def _run_behavioral_analyzer_on_source(source_path: str) -> List[Dict[str,
                 "is_safe": True,
                 "findings": {},
             }
-        ]
+        )
 
     return results
+
+
+async def _run_behavioral_analyzer_on_source(source_path: str) -> List[Dict[str, Any]]:
+    """Run behavioral analyzer on source code and format results.
+
+    Args:
+        source_path: Path to Python file or directory to analyze
+
+    Returns:
+        List of formatted result dictionaries containing every MCP tool the
+        analyzer visited, regardless of whether it produced a finding. Tools
+        with no behavioral mismatch are included with ``is_safe=True``.
+    """
+    from mcpscanner.core.analyzers.behavioral import BehavioralCodeAnalyzer
+
+    cfg = _build_config([AnalyzerEnum.BEHAVIORAL])
+    analyzer = BehavioralCodeAnalyzer(cfg)
+
+    findings = await analyzer.analyze(source_path, context={"file_path": source_path})
+
+    return _build_behavioral_results(analyzer, findings, source_path)
 
 
 async def scan_mcp_server_direct(
@@ -1906,121 +2008,29 @@ async def main():
                 source_path, context={"file_path": source_path}
             )
 
-            # Format results to match Scanner output structure
-            # Group findings by function to create tool-like results
-            findings_by_function = {}
-            for finding in findings:
-                # Extract function name from details (not summary!)
-                func_name = (
-                    finding.details.get("function_name", "unknown")
-                    if finding.details
-                    else "unknown"
-                )
+            # Build a result entry for every analyzed MCP tool — including
+            # tools with no findings (is_safe=True). This ensures the scan
+            # output enumerates ALL tools detected during the scan, not only
+            # tools flagged as malicious.
+            results = _build_behavioral_results(analyzer, findings, source_path)
 
-                if func_name not in findings_by_function:
-                    findings_by_function[func_name] = []
-                findings_by_function[func_name].append(finding)
-
-            # Create ToolScanResult-like structure for each function
-            results = []
-            for func_name, func_findings in findings_by_function.items():
-                # Get highest severity
-                severity_order = {
-                    "HIGH": 3,
-                    "MEDIUM": 2,
-                    "LOW": 1,
-                    "SAFE": 0,
-                    "UNKNOWN": 0,
-                }
-                max_severity = max(
-                    (f.severity for f in func_findings),
-                    key=lambda s: severity_order.get(s, 0),
-                )
-
-                # Get source file from findings (for directory scans)
-                source_file = (
-                    func_findings[0].details.get("source_file", source_path)
-                    if func_findings[0].details
-                    else source_path
-                )
-
-                display_name = (
-                    os.path.basename(source_file)
-                    if source_file != source_path
-                    else source_path
-                )
-
-                # Collect all taxonomies from findings
-                mcp_taxonomies = []
-                for finding in func_findings:
-                    if hasattr(finding, "mcp_taxonomy") and finding.mcp_taxonomy:
-                        if finding.mcp_taxonomy not in mcp_taxonomies:
-                            mcp_taxonomies.append(finding.mcp_taxonomy)
-
-                # Get threat/vulnerability classification from first finding
-                threat_vuln_classification = None
-                if func_findings and func_findings[0].details:
-                    threat_vuln_classification = func_findings[0].details.get(
-                        "threat_vulnerability_classification"
-                    )
-
-                # Determine if safe based on severity
-                is_safe = max_severity in ["SAFE", "LOW"]
-
-                analyzer_finding = {
-                    "severity": max_severity,
-                    "threat_summary": func_findings[0].summary,
-                    "threat_names": list(
-                        set([f.threat_category for f in func_findings])
-                    ),  # Deduplicate
-                    "total_findings": len(func_findings),
-                    "source_file": source_file,  # Include source file in output
-                    "mcp_taxonomies": mcp_taxonomies,  # All unique taxonomies
-                }
-
-                # Add threat/vulnerability classification if available
-                if threat_vuln_classification:
-                    analyzer_finding["threat_vulnerability_classification"] = (
-                        threat_vuln_classification
-                    )
-
-                results.append(
-                    {
-                        "tool_name": func_name,  # This should match the name from decorator params or function name
-                        "tool_description": f"MCP function from {display_name}",
-                        "status": "completed",
-                        "is_safe": is_safe,
-                        "findings": {"behavioral_analyzer": analyzer_finding},
-                    }
-                )
-
-            # If no findings, all functions are safe
-            if not results:
-                results.append(
-                    {
-                        "tool_name": source_path,
-                        "tool_description": "MCP server source code",
-                        "status": "completed",
-                        "is_safe": True,
-                        "findings": {},
-                    }
-                )
-
-            # Automatically filter out VULNERABILITY findings - only show THREATS
+            # Filter out VULNERABILITY findings — only surface THREATS — while
+            # always keeping safe results so every analyzed tool remains
+            # visible in the output.
             filtered_results = []
             for result in results:
-                # Check if result has behavioral_analyzer findings with classification
-                if "findings" in result and "behavioral_analyzer" in result["findings"]:
-                    analyzer_data = result["findings"]["behavioral_analyzer"]
-                    classification = analyzer_data.get(
-                        "threat_vulnerability_classification", ""
-                    ).upper()
+                if result.get("is_safe", False):
+                    filtered_results.append(result)
+                    continue
 
-                    # Only include THREAT findings, exclude VULNERABILITY
-                    if classification == "THREAT":
-                        filtered_results.append(result)
-                # Keep results without findings (safe results)
-                elif not result.get("findings"):
+                analyzer_data = result.get("findings", {}).get(
+                    "behavioral_analyzer", {}
+                )
+                classification = (
+                    analyzer_data.get("threat_vulnerability_classification") or ""
+                ).upper()
+
+                if classification == "THREAT":
                     filtered_results.append(result)
 
             results = filtered_results

--- a/mcpscanner/core/analyzers/behavioral/code_analyzer.py
+++ b/mcpscanner/core/analyzers/behavioral/code_analyzer.py
@@ -74,6 +74,12 @@ class BehavioralCodeAnalyzer(BaseAnalyzer):
         # Initialize alignment orchestrator (handles all LLM interaction)
         self.alignment_orchestrator = AlignmentOrchestrator(config)
 
+        # Tracks every MCP tool/function that was analyzed during the most recent
+        # analyze() call, regardless of whether a finding was produced. This lets
+        # callers report on ALL tools detected during a scan (safe and unsafe),
+        # not only the ones that triggered a SecurityFinding.
+        self.analyzed_functions: List[Dict[str, Any]] = []
+
         self.logger.debug(
             "BehavioralCodeAnalyzer initialized with alignment verification"
         )
@@ -92,6 +98,8 @@ class BehavioralCodeAnalyzer(BaseAnalyzer):
         """
         try:
             all_findings = []
+            # Reset per-call so consumers see only tools from this invocation.
+            self.analyzed_functions = []
 
             # Check if content is a directory
             if os.path.isdir(content):
@@ -454,6 +462,20 @@ class BehavioralCodeAnalyzer(BaseAnalyzer):
             if not func_contexts:
                 self.logger.debug(f"No functions found in {file_path}")
                 return findings
+
+            # Record every function we are about to analyze so that callers
+            # can enumerate all tools detected during the scan (including
+            # functions that later come back clean with no findings).
+            for fc in func_contexts:
+                self.analyzed_functions.append(
+                    {
+                        "name": getattr(fc, "name", "unknown"),
+                        "decorator_types": list(getattr(fc, "decorator_types", []) or []),
+                        "line_number": getattr(fc, "line_number", 0),
+                        "source_file": file_path,
+                        "docstring": getattr(fc, "docstring", None) or "",
+                    }
+                )
 
             self.logger.debug(f"Analyzing {len(func_contexts)} functions in {file_path}")
 

--- a/mcpscanner/core/report_generator.py
+++ b/mcpscanner/core/report_generator.py
@@ -578,7 +578,7 @@ class ReportGenerator:
                 "INFO": "🔵",
                 "SAFE": "🟢",
             }
-            severity_icon = severity_emojis.get(highest_severity, "🟢")
+            severity_icon = severity_emojis.get(highest_severity, "🟣")
             output.append(f"{severity_icon} {tool_name} ({highest_severity})")
 
             if total_findings > 0:
@@ -684,14 +684,20 @@ class ReportGenerator:
                     }
                 )
 
-        # Sort by severity priority
-        severity_order = ["HIGH", "UNKNOWN", "MEDIUM", "LOW", "SAFE"]
+        # Sort by severity priority. UNKNOWN goes last because per the
+        # rollup contract it represents "not yet analyzed" rather than a
+        # confirmed concrete severity, so a tool with both UNKNOWN and any
+        # concrete finding would have already been bucketed into the
+        # concrete bucket; surfacing UNKNOWN-only items at the bottom keeps
+        # the eye on confirmed risk first.
+        severity_order = ["HIGH", "MEDIUM", "LOW", "INFO", "SAFE", "UNKNOWN"]
         severity_emojis = {
             "HIGH": "🔴",
-            "UNKNOWN": "🔴",
             "MEDIUM": "🟠",
             "LOW": "🟡",
+            "INFO": "🔵",
             "SAFE": "🟢",
+            "UNKNOWN": "🟣",
         }
 
         for severity in severity_order:
@@ -699,7 +705,7 @@ class ReportGenerator:
                 continue
 
             items = severity_groups[severity]
-            emoji = severity_emojis.get(severity, "🔴")
+            emoji = severity_emojis.get(severity, "🟣")
             output.append(f"{emoji} {severity} SEVERITY ({len(items)} items)")
 
             for item in items:
@@ -821,10 +827,10 @@ class ReportGenerator:
                     f.get("severity", "UNKNOWN") for f in findings.values()
                 ]
                 severity_text = get_highest_severity(severities)
-                severity_emoji = severity_emojis.get(severity_text, "🟢")
+                severity_emoji = severity_emojis.get(severity_text, "🟣")
                 overall_severity = f"{severity_emoji} {severity_text}"[:8]
             else:
-                severity_emoji = severity_emojis.get(status, "🟢")
+                severity_emoji = severity_emojis.get(status, "🟣")
                 overall_severity = f"{severity_emoji} {status}"[:8]
 
             if self.is_vuln_pkg_scan:

--- a/mcpscanner/core/report_generator.py
+++ b/mcpscanner/core/report_generator.py
@@ -380,7 +380,7 @@ class ReportGenerator:
                 analyzer_data.get("severity", "UNKNOWN")
                 for analyzer_data in findings.values()
             ]
-            highest_severity = self._get_highest_severity(severities)
+            highest_severity = get_highest_severity(severities)
             total_findings = sum(
                 analyzer_data.get("total_findings", 0)
                 for analyzer_data in findings.values()
@@ -567,7 +567,7 @@ class ReportGenerator:
             # Get summary info
             total_findings = sum(f.get("total_findings", 0) for f in findings.values())
             severities = [f.get("severity", "UNKNOWN") for f in findings.values()]
-            highest_severity = self._get_highest_severity(severities)
+            highest_severity = get_highest_severity(severities)
 
             # Use colored emojis based on severity
             severity_emojis = {
@@ -820,7 +820,7 @@ class ReportGenerator:
                 severities = [
                     f.get("severity", "UNKNOWN") for f in findings.values()
                 ]
-                severity_text = self._get_highest_severity(severities)
+                severity_text = get_highest_severity(severities)
                 severity_emoji = severity_emojis.get(severity_text, "🟢")
                 overall_severity = f"{severity_emoji} {severity_text}"[:8]
             else:
@@ -852,19 +852,6 @@ class ReportGenerator:
             output.append(row)
 
         return "\n".join(output)
-
-    def _get_highest_severity(self, severities: List[str]) -> str:
-        """Roll up a list of severities into the single highest severity.
-
-        Delegates to :func:`mcpscanner.core.result.get_highest_severity` so the
-        rest of the codebase shares one severity model:
-
-        - ``UNKNOWN`` is the pre-analysis default and is *displaced* by any
-          concrete severity (``HIGH``, ``MEDIUM``, ``LOW``, ``INFO``, ``SAFE``).
-        - With no concrete severities (empty list or only ``UNKNOWN`` entries),
-          the rollup is ``UNKNOWN``.
-        """
-        return get_highest_severity(severities)
 
     def get_statistics(self) -> Dict[str, Any]:
         """Get statistics about the scan results."""

--- a/mcpscanner/core/report_generator.py
+++ b/mcpscanner/core/report_generator.py
@@ -357,44 +357,58 @@ class ReportGenerator:
         output.append(f"Unsafe items: {unsafe_count}")
 
         unsafe_results = [r for r in results if not r.get("is_safe", True)]
+        safe_results = [r for r in results if r.get("is_safe", True)]
+
+        def _render_item(idx: int, result: Dict[str, Any]) -> str:
+            item_type = result.get("item_type", "tool")
+
+            if item_type == "tool":
+                item_name = result.get(
+                    "tool_name", result.get("package_name", "Unknown")
+                )
+            elif item_type == "prompt":
+                item_name = result.get("prompt_name", "Unknown")
+            elif item_type == "resource":
+                item_name = result.get("resource_name", "Unknown")
+            else:
+                item_name = "Unknown"
+
+            findings = result.get("findings", {})
+
+            highest_severity = "SAFE"
+            total_findings = 0
+            for analyzer_data in findings.values():
+                severity = analyzer_data.get("severity", "SAFE")
+                if self._get_severity_order(severity) > self._get_severity_order(
+                    highest_severity
+                ):
+                    highest_severity = severity
+                total_findings += analyzer_data.get("total_findings", 0)
+
+            if "server_name" in result and result["server_name"]:
+                return (
+                    f"{idx}. {item_name} ({item_type}) "
+                    f"(Server: {result['server_name']}) - "
+                    f"{highest_severity} ({total_findings} findings)"
+                )
+            return (
+                f"{idx}. {item_name} ({item_type}) - "
+                f"{highest_severity} ({total_findings} findings)"
+            )
 
         if unsafe_results:
             output.append("\n=== Unsafe Items ===")
             for i, result in enumerate(unsafe_results, 1):
-                item_type = result.get("item_type", "tool")
+                output.append(_render_item(i, result))
 
-                # Get item name based on type
-                if item_type == "tool":
-                    item_name = result.get("tool_name", result.get("package_name", "Unknown"))
-                elif item_type == "prompt":
-                    item_name = result.get("prompt_name", "Unknown")
-                elif item_type == "resource":
-                    item_name = result.get("resource_name", "Unknown")
-                else:
-                    item_name = "Unknown"
-
-                findings = result.get("findings", {})
-
-                # Get the highest severity and total findings count
-                highest_severity = "SAFE"
-                total_findings = 0
-                for analyzer_data in findings.values():
-                    severity = analyzer_data.get("severity", "SAFE")
-                    if self._get_severity_order(severity) > self._get_severity_order(
-                        highest_severity
-                    ):
-                        highest_severity = severity
-                    total_findings += analyzer_data.get("total_findings", 0)
-
-                # Show server name for config-based scans
-                if "server_name" in result and result["server_name"]:
-                    output.append(
-                        f"{i}. {item_name} ({item_type}) (Server: {result['server_name']}) - {highest_severity} ({total_findings} findings)"
-                    )
-                else:
-                    output.append(
-                        f"{i}. {item_name} ({item_type}) - {highest_severity} ({total_findings} findings)"
-                    )
+        # Also enumerate safe items so the summary reflects ALL tools detected
+        # during the scan, not only the ones flagged as malicious. Callers that
+        # want to hide safe items should pass show_safe=False, which filters
+        # them out before this method is reached.
+        if safe_results:
+            output.append("\n=== Safe Items ===")
+            for i, result in enumerate(safe_results, 1):
+                output.append(_render_item(i, result))
 
         return "\n".join(output)
 

--- a/mcpscanner/core/report_generator.py
+++ b/mcpscanner/core/report_generator.py
@@ -25,6 +25,7 @@ import os
 from typing import Any, Dict, List, Optional, Union
 
 from .models import OutputFormat, SeverityFilter
+from .result import get_highest_severity
 
 
 async def results_to_json(scan_results) -> List[Dict[str, Any]]:
@@ -375,15 +376,15 @@ class ReportGenerator:
 
             findings = result.get("findings", {})
 
-            highest_severity = "SAFE"
-            total_findings = 0
-            for analyzer_data in findings.values():
-                severity = analyzer_data.get("severity", "SAFE")
-                if self._get_severity_order(severity) > self._get_severity_order(
-                    highest_severity
-                ):
-                    highest_severity = severity
-                total_findings += analyzer_data.get("total_findings", 0)
+            severities = [
+                analyzer_data.get("severity", "UNKNOWN")
+                for analyzer_data in findings.values()
+            ]
+            highest_severity = self._get_highest_severity(severities)
+            total_findings = sum(
+                analyzer_data.get("total_findings", 0)
+                for analyzer_data in findings.values()
+            )
 
             if "server_name" in result and result["server_name"]:
                 return (
@@ -565,15 +566,16 @@ class ReportGenerator:
 
             # Get summary info
             total_findings = sum(f.get("total_findings", 0) for f in findings.values())
-            severities = [f.get("severity", "SAFE") for f in findings.values()]
+            severities = [f.get("severity", "UNKNOWN") for f in findings.values()]
             highest_severity = self._get_highest_severity(severities)
 
             # Use colored emojis based on severity
             severity_emojis = {
                 "HIGH": "🔴",
-                "UNKNOWN": "🔴",
+                "UNKNOWN": "🟣",
                 "MEDIUM": "🟠",
                 "LOW": "🟡",
+                "INFO": "🔵",
                 "SAFE": "🟢",
             }
             severity_icon = severity_emojis.get(highest_severity, "🟢")
@@ -807,14 +809,17 @@ class ReportGenerator:
             # Get overall severity with colored emoji
             severity_emojis = {
                 "HIGH": "🔴",
-                "UNKNOWN": "🔴",
+                "UNKNOWN": "🟣",
                 "MEDIUM": "🟠",
                 "LOW": "🟡",
+                "INFO": "🔵",
                 "SAFE": "🟢",
             }
 
             if findings:
-                severities = [f.get("severity", "SAFE") for f in findings.values()]
+                severities = [
+                    f.get("severity", "UNKNOWN") for f in findings.values()
+                ]
                 severity_text = self._get_highest_severity(severities)
                 severity_emoji = severity_emojis.get(severity_text, "🟢")
                 overall_severity = f"{severity_emoji} {severity_text}"[:8]
@@ -849,23 +854,17 @@ class ReportGenerator:
         return "\n".join(output)
 
     def _get_highest_severity(self, severities: List[str]) -> str:
-        """Get the highest severity from a list."""
-        severity_order = {"HIGH": 5, "UNKNOWN": 4, "MEDIUM": 3, "LOW": 2, "SAFE": 1}
-        highest = "SAFE"
-        highest_value = 0
+        """Roll up a list of severities into the single highest severity.
 
-        for severity in severities:
-            value = severity_order.get(severity.upper(), 0)
-            if value > highest_value:
-                highest_value = value
-                highest = severity.upper()
+        Delegates to :func:`mcpscanner.core.result.get_highest_severity` so the
+        rest of the codebase shares one severity model:
 
-        return highest
-
-    def _get_severity_order(self, severity: str) -> int:
-        """Get the numeric order value for a severity level."""
-        severity_order = {"HIGH": 5, "UNKNOWN": 4, "MEDIUM": 3, "LOW": 2, "SAFE": 1}
-        return severity_order.get(severity.upper(), 0)
+        - ``UNKNOWN`` is the pre-analysis default and is *displaced* by any
+          concrete severity (``HIGH``, ``MEDIUM``, ``LOW``, ``INFO``, ``SAFE``).
+        - With no concrete severities (empty list or only ``UNKNOWN`` entries),
+          the rollup is ``UNKNOWN``.
+        """
+        return get_highest_severity(severities)
 
     def get_statistics(self) -> Dict[str, Any]:
         """Get statistics about the scan results."""

--- a/mcpscanner/core/result.py
+++ b/mcpscanner/core/result.py
@@ -389,6 +389,14 @@ def group_findings_by_analyzer(
 def get_highest_severity(severities: List[str]) -> str:
     """Get the highest severity from a list of severities.
 
+    Severity model:
+    - "UNKNOWN" represents "not yet analyzed" / "analyzer didn't run". It is the
+      pre-analysis default and is *displaced* by any concrete severity
+      ("HIGH", "MEDIUM", "LOW", "INFO", "SAFE") produced by an analyzer.
+    - When concrete severities are present, the highest among them wins.
+    - When the list is empty or contains only "UNKNOWN" entries, the result is
+      "UNKNOWN" (nothing concrete to roll up).
+
     Args:
         severities (List[str]): List of severity strings.
 
@@ -397,22 +405,19 @@ def get_highest_severity(severities: List[str]) -> str:
     """
     severity_order = {
         "HIGH": 5,
-        "UNKNOWN": 4,
-        "MEDIUM": 3,
-        "LOW": 2,
-        "INFO": 1,
-        "SAFE": 0,
+        "MEDIUM": 4,
+        "LOW": 3,
+        "INFO": 2,
+        "SAFE": 1,
     }
-    highest = "SAFE"
-    highest_value = 0
 
-    for severity in severities:
-        value = severity_order.get(severity.upper(), 0)
-        if value > highest_value:
-            highest_value = value
-            highest = severity.upper()
+    concrete = [
+        s.upper() for s in severities if s and s.upper() in severity_order
+    ]
+    if not concrete:
+        return "UNKNOWN"
 
-    return highest
+    return max(concrete, key=lambda s: severity_order[s])
 
 
 def format_results_as_json(

--- a/tests/test_severity_rollup.py
+++ b/tests/test_severity_rollup.py
@@ -1,0 +1,127 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Severity rollup contract tests.
+
+Locks in the model that ``UNKNOWN`` is the pre-analysis default and is
+displaced by any concrete severity (``HIGH``/``MEDIUM``/``LOW``/``INFO``/
+``SAFE``). After analysis the rollup is therefore always either ``SAFE``,
+one of the unsafe severities, or ``UNKNOWN`` (if no analyzer produced a
+concrete result).
+"""
+
+from typing import List
+
+import pytest
+
+from mcpscanner.core.report_generator import ReportGenerator
+from mcpscanner.core.result import get_highest_severity
+
+
+@pytest.mark.parametrize(
+    "severities,expected",
+    [
+        # Pre-analysis: nothing to roll up -> UNKNOWN.
+        ([], "UNKNOWN"),
+        # All analyzers failed / not run -> still UNKNOWN.
+        (["UNKNOWN"], "UNKNOWN"),
+        (["UNKNOWN", "UNKNOWN"], "UNKNOWN"),
+        # A single concrete result wins.
+        (["SAFE"], "SAFE"),
+        (["INFO"], "INFO"),
+        (["LOW"], "LOW"),
+        (["MEDIUM"], "MEDIUM"),
+        (["HIGH"], "HIGH"),
+        # UNKNOWN is displaced by ANY concrete severity, including SAFE.
+        (["SAFE", "UNKNOWN"], "SAFE"),
+        (["INFO", "UNKNOWN"], "INFO"),
+        (["LOW", "UNKNOWN"], "LOW"),
+        (["MEDIUM", "UNKNOWN"], "MEDIUM"),
+        (["HIGH", "UNKNOWN"], "HIGH"),
+        # Highest concrete severity wins.
+        (["INFO", "SAFE"], "INFO"),
+        (["INFO", "LOW"], "LOW"),
+        (["SAFE", "MEDIUM"], "MEDIUM"),
+        (["LOW", "MEDIUM", "HIGH"], "HIGH"),
+        # Mixed concrete + UNKNOWN.
+        (["LOW", "MEDIUM", "UNKNOWN"], "MEDIUM"),
+        (["HIGH", "UNKNOWN", "SAFE"], "HIGH"),
+        # Case-insensitive input.
+        (["safe", "high"], "HIGH"),
+        (["medium"], "MEDIUM"),
+        # Unknown labels are ignored as if they weren't there.
+        (["BOGUS"], "UNKNOWN"),
+        (["BOGUS", "LOW"], "LOW"),
+    ],
+)
+def test_get_highest_severity_rollup(severities: List[str], expected: str) -> None:
+    assert get_highest_severity(severities) == expected
+
+
+def test_get_highest_severity_ignores_falsy_entries() -> None:
+    """Empty / None entries should be skipped, not treated as concrete."""
+    assert get_highest_severity(["", None, "UNKNOWN"]) == "UNKNOWN"  # type: ignore[list-item]
+    assert get_highest_severity(["", None, "MEDIUM"]) == "MEDIUM"  # type: ignore[list-item]
+
+
+class _ReportGeneratorStub(ReportGenerator):
+    """Bypass ReportGenerator.__init__ — we only need the helper method."""
+
+    def __init__(self) -> None:  # noqa: D401 - intentional no-op
+        pass
+
+
+def test_report_generator_helper_delegates_to_shared_logic() -> None:
+    """ReportGenerator._get_highest_severity must mirror get_highest_severity."""
+    stub = _ReportGeneratorStub()
+
+    cases = [
+        [],
+        ["UNKNOWN"],
+        ["SAFE", "UNKNOWN"],
+        ["LOW", "UNKNOWN"],
+        ["MEDIUM", "UNKNOWN"],
+        ["HIGH", "UNKNOWN"],
+        ["INFO", "LOW", "MEDIUM", "HIGH"],
+    ]
+    for severities in cases:
+        assert stub._get_highest_severity(severities) == get_highest_severity(
+            severities
+        )
+
+
+def test_unknown_does_not_outrank_concrete_severities() -> None:
+    """Regression: UNKNOWN used to be ranked above MEDIUM/LOW. It must not."""
+    # If even one analyzer produced a concrete severity, UNKNOWN must lose.
+    assert get_highest_severity(["UNKNOWN", "LOW"]) == "LOW"
+    assert get_highest_severity(["UNKNOWN", "MEDIUM"]) == "MEDIUM"
+    assert get_highest_severity(["UNKNOWN", "SAFE"]) == "SAFE"
+    # And HIGH still wins over everything.
+    assert get_highest_severity(["UNKNOWN", "HIGH"]) == "HIGH"
+
+
+def test_post_analysis_rollup_is_never_unknown_when_anything_concrete() -> None:
+    """Invariant: post-analysis rollup is SAFE/UNSAFE iff at least one
+    analyzer produced a concrete severity. Only fully-unknown input rolls
+    up to UNKNOWN.
+    """
+    concrete_only = ["HIGH", "MEDIUM", "LOW", "INFO", "SAFE"]
+    for sev in concrete_only:
+        assert get_highest_severity([sev]) != "UNKNOWN"
+        assert get_highest_severity([sev, "UNKNOWN"]) != "UNKNOWN"
+
+    assert get_highest_severity([]) == "UNKNOWN"
+    assert get_highest_severity(["UNKNOWN", "UNKNOWN"]) == "UNKNOWN"

--- a/tests/test_severity_rollup.py
+++ b/tests/test_severity_rollup.py
@@ -27,7 +27,6 @@ from typing import List
 
 import pytest
 
-from mcpscanner.core.report_generator import ReportGenerator
 from mcpscanner.core.result import get_highest_severity
 
 
@@ -77,30 +76,25 @@ def test_get_highest_severity_ignores_falsy_entries() -> None:
     assert get_highest_severity(["", None, "MEDIUM"]) == "MEDIUM"  # type: ignore[list-item]
 
 
-class _ReportGeneratorStub(ReportGenerator):
-    """Bypass ReportGenerator.__init__ — we only need the helper method."""
+def test_report_generator_uses_shared_helper() -> None:
+    """ReportGenerator must delegate severity rollup to get_highest_severity
+    rather than maintaining its own implementation. Guards against the helper
+    drifting back into a private duplicate inside report_generator.py.
+    """
+    import inspect
 
-    def __init__(self) -> None:  # noqa: D401 - intentional no-op
-        pass
+    from mcpscanner.core import report_generator as rg
 
+    # No private wrapper named _get_highest_severity should live on the class.
+    assert not hasattr(rg.ReportGenerator, "_get_highest_severity"), (
+        "ReportGenerator._get_highest_severity has been removed; callers "
+        "should use mcpscanner.core.result.get_highest_severity directly."
+    )
 
-def test_report_generator_helper_delegates_to_shared_logic() -> None:
-    """ReportGenerator._get_highest_severity must mirror get_highest_severity."""
-    stub = _ReportGeneratorStub()
-
-    cases = [
-        [],
-        ["UNKNOWN"],
-        ["SAFE", "UNKNOWN"],
-        ["LOW", "UNKNOWN"],
-        ["MEDIUM", "UNKNOWN"],
-        ["HIGH", "UNKNOWN"],
-        ["INFO", "LOW", "MEDIUM", "HIGH"],
-    ]
-    for severities in cases:
-        assert stub._get_highest_severity(severities) == get_highest_severity(
-            severities
-        )
+    # And the module should import the shared helper so call sites can use it.
+    src = inspect.getsource(rg)
+    assert "from .result import get_highest_severity" in src
+    assert "get_highest_severity(" in src
 
 
 def test_unknown_does_not_outrank_concrete_severities() -> None:


### PR DESCRIPTION
The behavioral scanner previously emitted results only for tools with findings, so benign tools were silently dropped from CLI output and summaries. Track every analyzed function in BehavioralCodeAnalyzer, build a ScanResult per tool (safe or unsafe) in the CLI, and render a dedicated Safe Items section in the summary report. This gives users full visibility into what was scanned, matching the behavior expected for remote/static scans.
