### PR TITLE
security: reject symlinks that escape the scan root in directory scans

### DIFF
--- a/mcpscanner/core/analyzers/behavioral/code_analyzer.py
+++ b/mcpscanner/core/analyzers/behavioral/code_analyzer.py
@@ -33,6 +33,7 @@ from typing import Any, Dict, List, Optional, Union
 from ....config.config import Config
 from ....config.constants import MCPScannerConstants
 from ....threats.threats import ThreatMapping
+from ....utils.path_safety import filter_safe_paths, safe_resolve_root
 from ...static_analysis.context_extractor import ContextExtractor
 from ...static_analysis.native_analyzer import NativeAnalyzer
 from ...static_analysis.interprocedural.call_graph_analyzer import CallGraphAnalyzer
@@ -300,9 +301,15 @@ class BehavioralCodeAnalyzer(BaseAnalyzer):
         """
         source_files = []
         path = Path(directory)
+        # Resolve the scan root once; every candidate is checked against this
+        # canonical path so symlinks that point outside the scan root are
+        # rejected before the analyzer ever opens the file. See
+        # mcpscanner/utils/path_safety.py for the rationale.
+        resolved_root = safe_resolve_root(directory)
 
         extensions = self._PYTHON_EXTENSIONS | set(self._EXT_TO_TS_LANGUAGE.keys())
 
+        candidates: List[Path] = []
         for ext in extensions:
             for source_file in path.rglob(f"*{ext}"):
                 file_str = str(source_file)
@@ -311,7 +318,13 @@ class BehavioralCodeAnalyzer(BaseAnalyzer):
                     and "node_modules" not in file_str
                     and not any(part.startswith(".") for part in source_file.parts)
                 ):
-                    source_files.append(file_str)
+                    candidates.append(source_file)
+
+        safe_candidates, _skipped = filter_safe_paths(
+            candidates, resolved_root, audit_label="behavioral"
+        )
+        for source_file in safe_candidates:
+            source_files.append(str(source_file))
 
         return sorted(source_files)
 
@@ -324,14 +337,22 @@ class BehavioralCodeAnalyzer(BaseAnalyzer):
         Returns:
             List of Python file paths
         """
-        python_files = []
+        python_files: List[str] = []
         path = Path(directory)
+        resolved_root = safe_resolve_root(directory)
 
+        candidates: List[Path] = []
         for py_file in path.rglob("*.py"):
             if "__pycache__" not in str(py_file) and not any(
                 part.startswith(".") for part in py_file.parts
             ):
-                python_files.append(str(py_file))
+                candidates.append(py_file)
+
+        safe_candidates, _skipped = filter_safe_paths(
+            candidates, resolved_root, audit_label="behavioral"
+        )
+        for py_file in safe_candidates:
+            python_files.append(str(py_file))
 
         return sorted(python_files)
 

--- a/mcpscanner/core/analyzers/virustotal_analyzer.py
+++ b/mcpscanner/core/analyzers/virustotal_analyzer.py
@@ -41,6 +41,7 @@ import httpx
 from ...threats.threats import ThreatMapping
 from .base import SecurityFinding
 from ...utils.file_magic import detect_magic
+from ...utils.path_safety import filter_safe_paths, safe_resolve_root
 
 logger = logging.getLogger(__name__)
 
@@ -613,13 +614,38 @@ class VirusTotalAnalyzer:
         """
         files: List[str] = []
         path = Path(directory)
+        # Resolve the scan root once so per-file membership checks compare
+        # against the canonical (symlink-free) form. Files whose resolved
+        # target lies outside the scan root are dropped — otherwise a
+        # symlink inside ``directory`` pointing at a sensitive file
+        # outside it would be hashed and (with vt_scan_files enabled)
+        # uploaded to VirusTotal. See utils/path_safety.py.
+        resolved_root = safe_resolve_root(directory)
 
+        candidates: List[Path] = []
         for file_path in path.rglob("*"):
-            if file_path.is_file():
-                if "__pycache__" not in str(file_path) and not any(
-                    part.startswith(".") for part in file_path.parts
-                ):
-                    files.append(str(file_path))
+            # Use ``is_file(follow_symlinks=False)`` so we judge the link
+            # itself, not its target — the resolution is enforced by
+            # ``filter_safe_paths`` immediately below. We still accept
+            # symlinks at this stage so that intra-root symlinks (a valid
+            # use case) survive; it is the *escape* check that gates them.
+            try:
+                is_regular = file_path.is_file()
+            except OSError:
+                continue
+            if not is_regular:
+                continue
+
+            if "__pycache__" not in str(file_path) and not any(
+                part.startswith(".") for part in file_path.parts
+            ):
+                candidates.append(file_path)
+
+        safe_candidates, _skipped = filter_safe_paths(
+            candidates, resolved_root, audit_label="virustotal"
+        )
+        for file_path in safe_candidates:
+            files.append(str(file_path))
 
         return sorted(files)
 

--- a/mcpscanner/utils/path_safety.py
+++ b/mcpscanner/utils/path_safety.py
@@ -1,0 +1,129 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Path-safety helpers used by directory-walking analyzers.
+
+The behavioural code analyzer and the VirusTotal analyzer both walk a
+user-supplied directory with ``Path.rglob`` and then read or hash each
+matching file. By default ``Path.rglob`` matches symlinked files, and
+``open()`` / ``Path.read_bytes()`` follow those links — so a hostile or
+careless directory layout that contains a symlink to a file outside the
+scan root would cause that external file to be ingested by the scanner
+(and, with the VT analyzer's upload mode, exfiltrated to VirusTotal).
+
+This module centralises the defence: resolve the scan root once, resolve
+each candidate, and reject anything whose canonical location escapes the
+root. Callers also get a single place to log the decision so audit trails
+are consistent across analyzers.
+
+The behaviour intentionally rejects symlinks whose target lies outside
+the scan root rather than rejecting all symlinks — symlinks that stay
+inside the project (e.g. ``node_modules/.bin``) are legitimate and would
+otherwise produce false negatives for legitimate scans.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def safe_resolve_root(directory: str | os.PathLike) -> Path:
+    """Resolve ``directory`` to an absolute, symlink-free canonical path.
+
+    The result is what every per-file ``is_within_root`` check is measured
+    against. ``strict=False`` lets us accept paths whose terminal component
+    does not yet exist (some test fixtures rely on that), but the rest of
+    the chain is still resolved.
+    """
+    return Path(directory).resolve(strict=False)
+
+
+def is_within_root(candidate: Path, resolved_root: Path) -> bool:
+    """Return ``True`` iff ``candidate`` resolves to a location inside
+    ``resolved_root``.
+
+    The check uses :py:meth:`Path.resolve` on the candidate so the answer
+    reflects the *target* of any intervening symlinks, not the symlink
+    name. ``resolved_root`` is expected to already be the output of
+    :func:`safe_resolve_root` — we do not re-resolve it on every call to
+    keep the per-file cost down on large trees.
+    """
+    try:
+        resolved_candidate = candidate.resolve(strict=False)
+    except (OSError, RuntimeError):
+        # ``resolve()`` can raise on broken symlinks or on cycles; treat
+        # both as "not safe to read" rather than propagating.
+        return False
+
+    if resolved_candidate == resolved_root:
+        return True
+    try:
+        resolved_candidate.relative_to(resolved_root)
+        return True
+    except ValueError:
+        return False
+
+
+def filter_safe_paths(
+    candidates,
+    resolved_root: Path,
+    *,
+    audit_label: str = "scan",
+) -> Tuple[list, int]:
+    """Filter an iterable of ``Path`` candidates down to ones that stay
+    inside ``resolved_root``.
+
+    Returns ``(safe_paths, skipped_count)``. Each rejected candidate is
+    logged at ``WARNING`` so an operator can see — after the fact — that
+    a symlink escape was attempted on the directory they handed to the
+    scanner. We deliberately do not log the symlink *target* at WARNING
+    level: that target is the very file the attacker tried to exfiltrate,
+    and echoing it into shared logs would defeat the defence. The target
+    is only emitted at DEBUG, where local operators can opt in.
+    """
+    safe: list = []
+    skipped = 0
+    for candidate in candidates:
+        if is_within_root(candidate, resolved_root):
+            safe.append(candidate)
+            continue
+
+        skipped += 1
+        try:
+            target_repr: Optional[str] = str(candidate.resolve(strict=False))
+        except Exception:
+            target_repr = None
+
+        logger.warning(
+            "[%s] skipping symlink that escapes scan root: %s",
+            audit_label,
+            candidate,
+        )
+        if target_repr is not None:
+            logger.debug(
+                "[%s] escape target was: %s (root=%s)",
+                audit_label,
+                target_repr,
+                resolved_root,
+            )
+    return safe, skipped
+
+
+__all__ = ["safe_resolve_root", "is_within_root", "filter_safe_paths"]

--- a/tests/test_path_safety_symlink_traversal.py
+++ b/tests/test_path_safety_symlink_traversal.py
@@ -1,0 +1,330 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the symlink-traversal hardening in directory scans.
+
+These tests cover both directly-affected analyzers
+(``BehavioralCodeAnalyzer`` and ``VirusTotalAnalyzer``) plus the shared
+``mcpscanner.utils.path_safety`` helper. The vulnerability they protect
+against:
+
+    A scanned directory contains a file symlink whose target lies outside
+    the scan root. ``Path.rglob`` matches it; ``open()`` / ``Path.read_*``
+    follows the link; the analyzer ingests (and, for VT with uploads
+    enabled, exfiltrates) a file outside the user-selected scope.
+
+The fix is to resolve every candidate path and reject anything whose
+canonical location escapes the scan root. Intra-root symlinks are still
+allowed — they are common in legitimate trees (e.g. ``node_modules/.bin``).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from mcpscanner.core.analyzers.behavioral.code_analyzer import BehavioralCodeAnalyzer
+from mcpscanner.core.analyzers.virustotal_analyzer import VirusTotalAnalyzer
+from mcpscanner.utils.path_safety import (
+    filter_safe_paths,
+    is_within_root,
+    safe_resolve_root,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def hostile_layout(tmp_path: Path) -> dict:
+    """Build a scanroot containing one benign file and one malicious symlink.
+
+    Layout::
+
+        tmp_path/
+          outside/
+            secret.py            <- target of the escape
+          scanroot/
+            normal_tool.py       <- benign, in-tree
+            innocent_looking.py  -> ../outside/secret.py    (file symlink, ESCAPES)
+
+    Returns a dict with the relevant paths so individual tests can pick
+    what they need.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.py"
+    secret.write_text("EXFIL_SECRET = 'should-never-be-read'\n")
+
+    scanroot = tmp_path / "scanroot"
+    scanroot.mkdir()
+    benign = scanroot / "normal_tool.py"
+    benign.write_text("def hello():\n    return 'hi'\n")
+
+    escape = scanroot / "innocent_looking.py"
+    os.symlink(secret, escape)
+
+    return {
+        "tmp": tmp_path,
+        "scanroot": scanroot,
+        "benign": benign,
+        "escape_link": escape,
+        "secret_target": secret,
+    }
+
+
+@pytest.fixture
+def intra_root_layout(tmp_path: Path) -> dict:
+    """Layout with a symlink that stays inside the scan root. Must NOT be skipped."""
+    scanroot = tmp_path / "scanroot"
+    scanroot.mkdir()
+
+    real = scanroot / "real.py"
+    real.write_text("X = 1\n")
+
+    link = scanroot / "alias.py"
+    os.symlink(real, link)
+
+    nested = scanroot / "pkg"
+    nested.mkdir()
+    nested_link = nested / "shortcut.py"
+    os.symlink(real, nested_link)
+
+    return {
+        "scanroot": scanroot,
+        "real": real,
+        "alias": link,
+        "nested_alias": nested_link,
+    }
+
+
+@pytest.fixture
+def broken_link_layout(tmp_path: Path) -> dict:
+    """Layout with a dangling symlink — must not raise, must be filtered."""
+    scanroot = tmp_path / "scanroot"
+    scanroot.mkdir()
+    real = scanroot / "ok.py"
+    real.write_text("ok = True\n")
+
+    dangling = scanroot / "dangling.py"
+    os.symlink(tmp_path / "does_not_exist.py", dangling)
+    return {"scanroot": scanroot, "real": real, "dangling": dangling}
+
+
+# ---------------------------------------------------------------------------
+# Helper-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestPathSafetyHelper:
+    def test_safe_resolve_root_returns_absolute_canonical(self, tmp_path: Path):
+        rel = tmp_path / "x"
+        rel.mkdir()
+        resolved = safe_resolve_root(str(rel))
+        assert resolved.is_absolute()
+        assert resolved == rel.resolve()
+
+    def test_is_within_root_accepts_in_tree(self, tmp_path: Path):
+        root = safe_resolve_root(str(tmp_path))
+        f = tmp_path / "child.py"
+        f.write_text("")
+        assert is_within_root(f, root) is True
+
+    def test_is_within_root_rejects_escape_via_symlink(self, hostile_layout):
+        root = safe_resolve_root(str(hostile_layout["scanroot"]))
+        assert is_within_root(hostile_layout["escape_link"], root) is False
+
+    def test_is_within_root_rejects_unrelated_absolute_path(self, tmp_path: Path):
+        root = safe_resolve_root(str(tmp_path / "scanroot"))
+        # ``/etc/passwd`` is the canonical example of a sensitive
+        # out-of-tree file; we just need any path that is definitely not
+        # under ``root``.
+        assert is_within_root(Path("/etc/passwd"), root) is False
+
+    def test_is_within_root_handles_resolution_error_safely(self, tmp_path: Path):
+        # Simulate a path object whose ``resolve`` raises — represent it
+        # via a broken symlink that resolve() handles fine in 3.11+, so we
+        # construct a resolution-failing scenario differently: pass a path
+        # under a directory that has been deleted. Should not raise.
+        root = safe_resolve_root(str(tmp_path))
+        bogus = tmp_path / "missing" / "x"  # parent doesn't exist
+        # ``resolve(strict=False)`` will succeed; just make sure no crash.
+        assert isinstance(is_within_root(bogus, root), bool)
+
+    def test_filter_safe_paths_separates_safe_and_skipped(self, hostile_layout, caplog):
+        root = safe_resolve_root(str(hostile_layout["scanroot"]))
+        candidates = [hostile_layout["benign"], hostile_layout["escape_link"]]
+
+        with caplog.at_level("WARNING"):
+            safe, skipped = filter_safe_paths(
+                candidates, root, audit_label="unit-test"
+            )
+
+        assert hostile_layout["benign"] in safe
+        assert hostile_layout["escape_link"] not in safe
+        assert skipped == 1
+
+        # The audit log must call out the symlink that escaped.
+        warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        assert any("symlink that escapes scan root" in w for w in warnings)
+        # And it must NOT echo the resolved escape target at WARNING — we
+        # don't want to mirror sensitive paths into shared log streams.
+        assert not any(
+            str(hostile_layout["secret_target"]) in w for w in warnings
+        )
+
+
+# ---------------------------------------------------------------------------
+# BehavioralCodeAnalyzer
+# ---------------------------------------------------------------------------
+
+
+class TestBehavioralCodeAnalyzerSymlinkSafety:
+    """Verify the source-file discovery path no longer ingests escapes."""
+
+    def _new_analyzer(self) -> BehavioralCodeAnalyzer:
+        # The analyzer's __init__ pulls in heavy LLM/static-analysis state
+        # we don't need here; the discovery method is pure.
+        return BehavioralCodeAnalyzer.__new__(BehavioralCodeAnalyzer)
+
+    def test_escape_symlink_is_not_returned_by_find_source_files(
+        self, hostile_layout
+    ):
+        analyzer = self._new_analyzer()
+        files = analyzer._find_source_files(str(hostile_layout["scanroot"]))
+
+        assert str(hostile_layout["benign"]) in files
+        assert str(hostile_layout["escape_link"]) not in files
+
+    def test_escape_symlink_is_not_returned_by_find_python_files(
+        self, hostile_layout
+    ):
+        analyzer = self._new_analyzer()
+        files = analyzer._find_python_files(str(hostile_layout["scanroot"]))
+
+        assert str(hostile_layout["benign"]) in files
+        assert str(hostile_layout["escape_link"]) not in files
+
+    def test_intra_root_symlinks_are_still_returned(self, intra_root_layout):
+        analyzer = self._new_analyzer()
+        files = analyzer._find_source_files(str(intra_root_layout["scanroot"]))
+
+        assert str(intra_root_layout["real"]) in files
+        # In-tree symlinks must still be picked up; they are a legitimate
+        # pattern (vendored bins, fixtures, etc.) and rejecting them would
+        # silently shrink scan coverage.
+        assert str(intra_root_layout["alias"]) in files
+        assert str(intra_root_layout["nested_alias"]) in files
+
+    def test_broken_symlink_does_not_crash(self, broken_link_layout):
+        analyzer = self._new_analyzer()
+        files = analyzer._find_source_files(str(broken_link_layout["scanroot"]))
+        # ``ok.py`` survives; the dangling link is dropped without exception.
+        assert str(broken_link_layout["real"]) in files
+        assert str(broken_link_layout["dangling"]) not in files
+
+
+# ---------------------------------------------------------------------------
+# VirusTotalAnalyzer
+# ---------------------------------------------------------------------------
+
+
+class TestVirusTotalAnalyzerSymlinkSafety:
+    """``_discover_files`` must reject escapes before anything is hashed
+    or uploaded. This covers the higher-impact half of the disclosure:
+    with ``vt_scan_files`` enabled, an unfiltered escape would be
+    uploaded to a third-party service."""
+
+    def _new_analyzer(self) -> VirusTotalAnalyzer:
+        return VirusTotalAnalyzer.__new__(VirusTotalAnalyzer)
+
+    def test_escape_symlink_is_not_discovered(self, hostile_layout):
+        analyzer = self._new_analyzer()
+        files = analyzer._discover_files(str(hostile_layout["scanroot"]))
+
+        assert str(hostile_layout["benign"]) in files
+        assert str(hostile_layout["escape_link"]) not in files
+
+    def test_intra_root_symlinks_are_still_discovered(self, intra_root_layout):
+        analyzer = self._new_analyzer()
+        files = analyzer._discover_files(str(intra_root_layout["scanroot"]))
+
+        assert str(intra_root_layout["real"]) in files
+        assert str(intra_root_layout["alias"]) in files
+        assert str(intra_root_layout["nested_alias"]) in files
+
+    def test_broken_symlink_does_not_crash(self, broken_link_layout):
+        analyzer = self._new_analyzer()
+        files = analyzer._discover_files(str(broken_link_layout["scanroot"]))
+        assert str(broken_link_layout["real"]) in files
+        assert str(broken_link_layout["dangling"]) not in files
+
+    def test_directory_symlink_pointing_outside_is_not_recursed(
+        self, tmp_path: Path
+    ):
+        """Defence-in-depth: even if a future ``rglob`` flag flips and
+        starts following directory symlinks, the per-file resolution
+        check here will still drop everything under an escaping link."""
+        outside = tmp_path / "outside_lib"
+        outside.mkdir()
+        (outside / "leaked.py").write_text("LEAK = 1\n")
+
+        scanroot = tmp_path / "scanroot"
+        scanroot.mkdir()
+        (scanroot / "normal.py").write_text("ok = 1\n")
+        os.symlink(outside, scanroot / "vendored")
+
+        analyzer = self._new_analyzer()
+        files = analyzer._discover_files(str(scanroot))
+
+        # The benign in-tree file is present.
+        assert str(scanroot / "normal.py") in files
+        # Nothing under the escaping directory symlink leaks in, even if
+        # an underlying glob implementation chose to recurse it.
+        assert not any("outside_lib" in f for f in files)
+        assert not any("leaked.py" in f for f in files)
+
+
+# ---------------------------------------------------------------------------
+# Symlink-cycle safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Symlink cycle creation is unreliable on Windows CI runners.",
+)
+def test_symlink_cycle_does_not_hang_or_crash(tmp_path: Path):
+    """A symlink cycle inside the scan root must not cause unbounded
+    work or an unhandled ``OSError`` from ``resolve()``."""
+    scanroot = tmp_path / "scanroot"
+    scanroot.mkdir()
+    (scanroot / "real.py").write_text("ok = 1\n")
+
+    a = scanroot / "loop_a"
+    b = scanroot / "loop_b"
+    os.symlink(b, a)
+    os.symlink(a, b)
+
+    analyzer = BehavioralCodeAnalyzer.__new__(BehavioralCodeAnalyzer)
+    files = analyzer._find_source_files(str(scanroot))
+
+    # ``real.py`` is returned; the cycle members do not cause an exception.
+    assert str(scanroot / "real.py") in files


### PR DESCRIPTION
Both BehavioralCodeAnalyzer and VirusTotalAnalyzer walked a user-supplied directory with Path.rglob and then opened or hashed each match. rglob matches symlinked files and the subsequent open()/read_bytes() follows them, so a symlink inside the scan root pointing at a sensitive file outside the root caused the external file to be ingested by the analyzer (and, with VT uploads enabled, exfiltrated to a third-party service).

Fix:
- New mcpscanner/utils/path_safety.py with safe_resolve_root / is_within_root / filter_safe_paths helpers. Each candidate is canonicalised and compared against a one-shot resolved root; anything escaping the root is dropped and logged at WARNING (the resolved escape target is only emitted at DEBUG to avoid mirroring sensitive paths into shared logs).
- Behavioral analyzer _find_source_files / _find_python_files route through filter_safe_paths.
- VirusTotal analyzer _discover_files routes through filter_safe_paths before any hashing happens.
- Intra-root symlinks are still allowed (e.g. node_modules/.bin) so scan coverage of legitimate trees is unchanged.

Adds tests/test_path_safety_symlink_traversal.py covering: helper behaviour, both analyzer discovery paths, intra-root symlinks, broken symlinks, escaping directory symlinks, and symlink cycles. All 15 new tests pass; full suite remains green (682 passed, 7 skipped).
