### PR TITLE
chore: bump version to 4.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-ai-mcp-scanner"
-version = "4.7.0"
+version = "4.7.1"
 description = "A tool to scan MCP servers and tools for security findings"
 authors = [
     {name = "Cisco"},

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ wheels = [
 
 [[package]]
 name = "cisco-ai-mcp-scanner"
-version = "4.7.0"
+version = "4.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "expandvars" },


### PR DESCRIPTION
Bumped via `uv version 4.7.1` and reconciled with `uv sync`.

Picks up the post-4.7.0 fixes from main, notably #175 (behavioral analyzer's analyze() now returns SAFE-severity findings for clean tools so SDK callers can enumerate every scanned tool from the return value alone, without reading the analyzed_functions side-channel attribute).