### PR TITLE
fix(behavioral): bring AlignmentLLMClient to parity with LLMAnalyzer'…

### DIFF
--- a/mcpscanner/core/analyzers/behavioral/alignment/alignment_llm_client.py
+++ b/mcpscanner/core/analyzers/behavioral/alignment/alignment_llm_client.py
@@ -49,33 +49,78 @@ class AlignmentLLMClient:
     def __init__(self, config: Config):
         """Initialize the alignment LLM client.
 
+        Mirrors ``LLMAnalyzer``'s tiered authentication strategy so the
+        behavioral path supports the same Bedrock options as the
+        tool-metadata path:
+
+          1. Non-Bedrock providers (OpenAI, Anthropic, Azure):
+             ``llm_provider_api_key`` is required.
+          2. Bedrock with API key (``MCP_SCANNER_LLM_API_KEY``): use it.
+          3. Bedrock with bearer token
+             (``AWS_BEARER_TOKEN_BEDROCK`` / ``Config.aws_bearer_token_bedrock``):
+             forward as ``api_key``.
+          4. Bedrock with neither: leave ``api_key`` unset and let
+             litellm/boto3 resolve credentials from the AWS provider
+             chain (profile / IAM role / web identity / session token).
+
         Args:
             config: Configuration containing LLM credentials and settings
 
         Raises:
-            ValueError: If LLM provider API key is not configured
+            ValueError: If a non-Bedrock provider is configured but no
+                ``llm_provider_api_key`` is set.
         """
-        if (
-            not hasattr(config, "llm_provider_api_key")
-            or not config.llm_provider_api_key
-        ):
-            raise ValueError(
-                "LLM provider API key is required for alignment verification"
-            )
-
-        # Store configuration for per-request usage
-        self._api_key = config.llm_provider_api_key
-        self._base_url = config.llm_base_url
-        self._api_version = config.llm_api_version
-
-        # Model configuration
+        # Model configuration (read first so the auth branch can use it).
         self._model = config.llm_model
         self._max_tokens = config.llm_max_tokens
         self._temperature = config.llm_temperature
         self._llm_timeout = config.llm_timeout
+        self._base_url = config.llm_base_url
+        self._api_version = config.llm_api_version
+
+        is_bedrock = bool(self._model and "bedrock/" in self._model)
+        api_key = getattr(config, "llm_provider_api_key", None)
+        bearer_token = getattr(config, "aws_bearer_token_bedrock", None)
+
+        if not is_bedrock:
+            if not api_key:
+                raise ValueError(
+                    "LLM provider API key is required for alignment verification"
+                )
+            self._api_key = api_key
+        else:
+            # Bedrock auth precedence: explicit api_key > bearer token > AWS provider chain.
+            if api_key:
+                self._api_key = api_key
+            elif bearer_token:
+                self._api_key = bearer_token
+            else:
+                # IAM role / profile / session token resolved by litellm/boto3.
+                self._api_key = None
+
+        # AWS-specific knobs (only forwarded for Bedrock requests).
+        self._aws_region = config.aws_region_name if is_bedrock else None
+        self._aws_session_token = config.aws_session_token if is_bedrock else None
+        self._aws_profile_name = config.aws_profile_name if is_bedrock else None
 
         self.logger = logging.getLogger(__name__)
-        self.logger.debug(f"AlignmentLLMClient initialized with model: {self._model}")
+        if is_bedrock:
+            if self._api_key:
+                # Don't leak which mode (key vs bearer); both look identical
+                # downstream and the distinction is only useful in support tickets.
+                auth_kind = "api_key/bearer_token"
+            else:
+                auth_kind = "AWS provider chain (profile/IAM/session)"
+            self.logger.debug(
+                "AlignmentLLMClient initialized with bedrock model=%s region=%s auth=%s",
+                self._model,
+                self._aws_region,
+                auth_kind,
+            )
+        else:
+            self.logger.debug(
+                "AlignmentLLMClient initialized with model: %s", self._model
+            )
 
     async def verify_alignment(self, prompt: str) -> str:
         """Send alignment verification prompt to LLM with retry logic.
@@ -150,8 +195,13 @@ class AlignmentLLMClient:
                 "max_tokens": self._max_tokens,
                 "temperature": self._temperature,
                 "timeout": self._llm_timeout,
-                "api_key": self._api_key,
             }
+
+            # Only attach api_key when one was resolved. Bedrock with the
+            # AWS provider chain (profile/IAM/session token) must reach
+            # litellm with no api_key so boto3 can pick credentials up.
+            if self._api_key:
+                request_params["api_key"] = self._api_key
 
             # Only enable JSON mode for supported models/providers
             # Azure OpenAI with older API versions may not support this
@@ -163,6 +213,17 @@ class AlignmentLLMClient:
                 request_params["api_base"] = self._base_url
             if self._api_version:
                 request_params["api_version"] = self._api_version
+
+            # Forward AWS-specific routing parameters when running against
+            # Bedrock so litellm/boto3 hit the right region/profile/session
+            # token. These are stored as None for non-Bedrock models and
+            # therefore never appear in the request kwargs in that case.
+            if self._aws_region:
+                request_params["aws_region_name"] = self._aws_region
+            if self._aws_session_token:
+                request_params["aws_session_token"] = self._aws_session_token
+            if self._aws_profile_name:
+                request_params["aws_profile_name"] = self._aws_profile_name
 
             self.logger.debug(
                 f"Sending alignment verification request to {self._model}"

--- a/mcpscanner/core/scanner.py
+++ b/mcpscanner/core/scanner.py
@@ -132,13 +132,17 @@ class Scanner:
         self._api_analyzer = ApiAnalyzer(config) if config.api_key else None
         self._yara_analyzer = YaraAnalyzer(rules_dir=rules_dir)
 
-        # LLM analyzer can be used with either API key or Bedrock (AWS credentials)
+        # LLM analyzer can be used with either API key or Bedrock (AWS credentials).
+        # Behavioral analyzer follows the same gate now that AlignmentLLMClient
+        # supports Bedrock auth via bearer token / AWS provider chain.
         is_bedrock = config.llm_model and "bedrock/" in config.llm_model
         self._llm_analyzer = (
             LLMAnalyzer(config) if (config.llm_provider_api_key or is_bedrock) else None
         )
         self._behavioral_analyzer = (
-            BehavioralCodeAnalyzer(config) if config.llm_provider_api_key else None
+            BehavioralCodeAnalyzer(config)
+            if (config.llm_provider_api_key or is_bedrock)
+            else None
         )
         self._vt_analyzer = (
             VirusTotalAnalyzer(
@@ -213,7 +217,8 @@ class Scanner:
             and not self._behavioral_analyzer
         ):
             missing_requirements.append(
-                "Behavioral analyzer requested but MCP_SCANNER_LLM_API_KEY not configured"
+                "Behavioral analyzer requested but MCP_SCANNER_LLM_API_KEY not configured "
+                "(or AWS credentials for Bedrock models)"
             )
 
         if (

--- a/tests/behavioral/test_alignment_llm_client_bedrock.py
+++ b/tests/behavioral/test_alignment_llm_client_bedrock.py
@@ -1,0 +1,254 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for AlignmentLLMClient's Bedrock authentication and routing.
+
+Mirrors the auth tiers documented on ``LLMAnalyzer`` and asserts they
+also apply to the behavioral path:
+
+  1. Non-Bedrock providers REQUIRE an api_key (regression guard).
+  2. Bedrock + api_key uses the api_key.
+  3. Bedrock + bearer token (no api_key) uses the bearer token.
+  4. Bedrock alone leaves api_key unset so litellm/boto3 resolve via
+     the AWS provider chain (profile / IAM / session token).
+
+Per-request, AWS-specific routing parameters (``aws_region_name``,
+``aws_session_token``, ``aws_profile_name``) are forwarded to
+``acompletion`` only for Bedrock requests.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from mcpscanner.config.config import Config
+from mcpscanner.core.analyzers.behavioral.alignment.alignment_llm_client import (
+    AlignmentLLMClient,
+)
+
+
+def _bedrock_config(**overrides) -> Config:
+    """Construct a Config that targets a Bedrock model by default."""
+    base = {
+        "llm_model": "bedrock/us.anthropic.claude-haiku-4-5-20250929-v1:0",
+        "aws_region_name": "us-west-2",
+    }
+    base.update(overrides)
+    return Config(**base)
+
+
+def _non_bedrock_config(**overrides) -> Config:
+    base = {"llm_model": "gpt-4o", "llm_provider_api_key": "sk-test"}
+    base.update(overrides)
+    return Config(**base)
+
+
+# ---------------------------------------------------------------------------
+# __init__ — auth strategy by provider
+# ---------------------------------------------------------------------------
+
+
+class TestAlignmentLLMClientInitAuth:
+    """Cover the four init-time auth tiers."""
+
+    def test_non_bedrock_without_api_key_raises(self):
+        """Regression: non-Bedrock providers still require an api_key."""
+        cfg = Config(llm_model="gpt-4o", llm_provider_api_key=None)
+        with pytest.raises(ValueError, match="LLM provider API key is required"):
+            AlignmentLLMClient(cfg)
+
+    def test_non_bedrock_with_api_key_uses_it(self):
+        cfg = _non_bedrock_config(llm_provider_api_key="sk-prod")
+        client = AlignmentLLMClient(cfg)
+        assert client._api_key == "sk-prod"
+        # Non-Bedrock requests must NOT receive AWS routing knobs.
+        assert client._aws_region is None
+        assert client._aws_session_token is None
+        assert client._aws_profile_name is None
+
+    def test_bedrock_with_api_key_prefers_api_key(self):
+        cfg = _bedrock_config(
+            llm_provider_api_key="bedrock-api-key",
+            aws_bearer_token_bedrock="bearer-should-be-ignored",
+        )
+        client = AlignmentLLMClient(cfg)
+        # api_key wins over bearer token (matches LLMAnalyzer ordering).
+        assert client._api_key == "bedrock-api-key"
+        assert client._aws_region == "us-west-2"
+
+    def test_bedrock_with_bearer_token_only_uses_bearer(self):
+        cfg = _bedrock_config(
+            aws_bearer_token_bedrock="long-lived-bedrock-bearer-token-1234",
+        )
+        client = AlignmentLLMClient(cfg)
+        assert client._api_key == "long-lived-bedrock-bearer-token-1234"
+        assert client._aws_region == "us-west-2"
+
+    def test_bedrock_with_no_credentials_uses_provider_chain(self):
+        """Bedrock + no api_key + no bearer token → IAM / profile / session.
+
+        This is the case that used to raise. The behavioral path is now
+        on parity with LLMAnalyzer.
+        """
+        cfg = _bedrock_config()
+        # Should not raise.
+        client = AlignmentLLMClient(cfg)
+        assert client._api_key is None
+        assert client._aws_region == "us-west-2"
+
+    def test_bedrock_session_and_profile_stored(self):
+        cfg = _bedrock_config(
+            aws_session_token="STS-TOKEN-XYZ",
+            aws_profile_name="prod-bedrock",
+        )
+        client = AlignmentLLMClient(cfg)
+        assert client._aws_session_token == "STS-TOKEN-XYZ"
+        assert client._aws_profile_name == "prod-bedrock"
+
+
+# ---------------------------------------------------------------------------
+# _make_llm_request — request-time parameter forwarding
+# ---------------------------------------------------------------------------
+
+
+def _stub_acompletion_response():
+    """Build a minimal litellm-shaped response object for tests."""
+    msg = type("Msg", (), {"content": '{"is_malicious": false}'})()
+    choice = type("Choice", (), {"message": msg})()
+    return type("Resp", (), {"choices": [choice]})()
+
+
+class TestAlignmentLLMClientRequestForwarding:
+    """Validate the kwargs sent to ``acompletion`` per provider."""
+
+    @pytest.mark.asyncio
+    async def test_non_bedrock_request_omits_aws_kwargs(self):
+        cfg = _non_bedrock_config()
+        client = AlignmentLLMClient(cfg)
+
+        with patch(
+            "mcpscanner.core.analyzers.behavioral.alignment."
+            "alignment_llm_client.acompletion",
+            new=AsyncMock(return_value=_stub_acompletion_response()),
+        ) as mocked:
+            await client._make_llm_request("hello")
+
+        kwargs = mocked.await_args.kwargs
+        assert kwargs["api_key"] == "sk-test"
+        # AWS routing knobs MUST NOT leak into non-Bedrock requests.
+        assert "aws_region_name" not in kwargs
+        assert "aws_session_token" not in kwargs
+        assert "aws_profile_name" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_bedrock_with_iam_omits_api_key(self):
+        """Bedrock + AWS provider chain must reach litellm with no api_key."""
+        cfg = _bedrock_config()
+        client = AlignmentLLMClient(cfg)
+
+        with patch(
+            "mcpscanner.core.analyzers.behavioral.alignment."
+            "alignment_llm_client.acompletion",
+            new=AsyncMock(return_value=_stub_acompletion_response()),
+        ) as mocked:
+            await client._make_llm_request("hello")
+
+        kwargs = mocked.await_args.kwargs
+        # Critical: api_key absent so litellm/boto3 fall through to IAM.
+        assert "api_key" not in kwargs
+        assert kwargs["aws_region_name"] == "us-west-2"
+
+    @pytest.mark.asyncio
+    async def test_bedrock_with_bearer_token_forwards_as_api_key(self):
+        cfg = _bedrock_config(aws_bearer_token_bedrock="bearer-xyz-abcdefghij")
+        client = AlignmentLLMClient(cfg)
+
+        with patch(
+            "mcpscanner.core.analyzers.behavioral.alignment."
+            "alignment_llm_client.acompletion",
+            new=AsyncMock(return_value=_stub_acompletion_response()),
+        ) as mocked:
+            await client._make_llm_request("hello")
+
+        kwargs = mocked.await_args.kwargs
+        assert kwargs["api_key"] == "bearer-xyz-abcdefghij"
+        assert kwargs["aws_region_name"] == "us-west-2"
+
+    @pytest.mark.asyncio
+    async def test_bedrock_session_and_profile_forwarded(self):
+        cfg = _bedrock_config(
+            aws_session_token="STS-TOKEN-XYZ",
+            aws_profile_name="prod-bedrock",
+        )
+        client = AlignmentLLMClient(cfg)
+
+        with patch(
+            "mcpscanner.core.analyzers.behavioral.alignment."
+            "alignment_llm_client.acompletion",
+            new=AsyncMock(return_value=_stub_acompletion_response()),
+        ) as mocked:
+            await client._make_llm_request("hello")
+
+        kwargs = mocked.await_args.kwargs
+        assert kwargs["aws_session_token"] == "STS-TOKEN-XYZ"
+        assert kwargs["aws_profile_name"] == "prod-bedrock"
+
+    @pytest.mark.asyncio
+    async def test_request_disables_json_mode_for_azure(self):
+        """The Azure exemption from LLM-side JSON mode must still apply."""
+        cfg = Config(
+            llm_model="azure/gpt-4",
+            llm_provider_api_key="key",
+            llm_api_version="2024-02-15-preview",
+        )
+        client = AlignmentLLMClient(cfg)
+
+        with patch(
+            "mcpscanner.core.analyzers.behavioral.alignment."
+            "alignment_llm_client.acompletion",
+            new=AsyncMock(return_value=_stub_acompletion_response()),
+        ) as mocked:
+            await client._make_llm_request("hello")
+
+        kwargs = mocked.await_args.kwargs
+        assert "response_format" not in kwargs
+        assert kwargs["api_version"] == "2024-02-15-preview"
+
+
+# ---------------------------------------------------------------------------
+# Scanner gate parity (no separate file because the test is one assertion).
+# ---------------------------------------------------------------------------
+
+
+class TestScannerBedrockBehavioralGate:
+    """Scanner.behavioral_analyzer should initialize for Bedrock-only configs."""
+
+    def test_scanner_initializes_behavioral_with_bedrock_only(self):
+        from mcpscanner.core.scanner import Scanner
+
+        cfg = _bedrock_config()  # no api_key, no bearer token
+        scanner = Scanner(cfg)
+        # Used to be None on main; now mirrors the LLM analyzer gate.
+        assert scanner._behavioral_analyzer is not None
+
+    def test_scanner_skips_behavioral_when_no_credentials_for_non_bedrock(self):
+        from mcpscanner.core.scanner import Scanner
+
+        cfg = Config(llm_model="gpt-4o")  # no api key, non-Bedrock
+        scanner = Scanner(cfg)
+        assert scanner._behavioral_analyzer is None


### PR DESCRIPTION

The behavioral analyzer's LLM client previously required `llm_provider_api_key` to be non-empty in `Config` for *every* model — including `bedrock/*` — and never forwarded `aws_region_name` / `aws_session_token` / `aws_profile_name` to its `acompletion` call. That blocked pure IAM-role auth on the behavioral path even though `LLMAnalyzer` had supported it for months and forced deployers (e.g., the inventory pipeline's behavioral Lambda) to smuggle a long-lived Bedrock bearer token in as `llm_provider_api_key` to satisfy the init-time guard.

This change mirrors `LLMAnalyzer`'s tiered auth strategy in `AlignmentLLMClient`:

  1. Non-Bedrock providers — `llm_provider_api_key` still required (regression guard preserved by `test_non_bedrock_without_api_key_raises`).
  2. Bedrock + `MCP_SCANNER_LLM_API_KEY` — forwarded as `api_key`.
  3. Bedrock + `AWS_BEARER_TOKEN_BEDROCK` — forwarded as `api_key` (litellm's bedrock provider treats them the same on the wire).
  4. Bedrock with neither — `api_key` is omitted from the request kwargs so litellm/boto3 fall through to the AWS provider chain (profile / IAM role / web identity / `AWS_SESSION_TOKEN`).

Per-request, `aws_region_name`, `aws_session_token`, and `aws_profile_name` are now forwarded to `acompletion` when a Bedrock model is configured. They are stored as `None` for non-Bedrock models and therefore never leak into OpenAI / Azure / Anthropic-direct requests.

Scanner gate (`mcpscanner/core/scanner.py`) is updated to mirror the LLM analyzer: `BehavioralCodeAnalyzer` is initialized when either `llm_provider_api_key` *or* a Bedrock model is configured, and the `_validate_analyzer_requirements` error message now mentions the AWS credentials path so operators don't get a misleading "API key not configured" message for IAM-only deploys.

Tests
-----
`tests/behavioral/test_alignment_llm_client_bedrock.py` covers the four init tiers and verifies the per-request kwargs forwarded to `acompletion`:

  * non-Bedrock without api_key still raises (regression)
  * Bedrock + api_key uses api_key
  * Bedrock + bearer token (no api_key) uses bearer token
  * Bedrock alone leaves api_key unset (IAM/profile/session)
  * non-Bedrock requests omit AWS routing kwargs
  * Bedrock-IAM requests omit `api_key` so boto3 can resolve credentials
  * Bedrock requests forward `aws_region_name`, `aws_session_token`, and `aws_profile_name`
  * Azure JSON-mode exemption still applies
  * `Scanner` initializes the behavioral analyzer for Bedrock-only configs and skips it for non-Bedrock no-credential configs

Downstream impact
-----------------
The inventory pipeline's behavioral Lambda
(`mcp-asset-inventory/src/scanners/behavioral/handler.py`) can drop the "Bedrock bearer token doubles as `llm_provider_api_key`" workaround in a follow-up change once consumers are on a release that includes this fix — the Lambda will run on its execution-role IAM credentials with no token plumbing.