### PR TITLE
fix(behavioral): emit ERROR not SAFE when LLM verification fails

### DIFF
--- a/mcpscanner/cli.py
+++ b/mcpscanner/cli.py
@@ -212,7 +212,20 @@ def _build_behavioral_results(
         src_file = details.get("source_file", source_path)
         findings_by_key.setdefault((src_file, func_name), []).append(finding)
 
-    severity_order = {"HIGH": 3, "MEDIUM": 2, "LOW": 1, "SAFE": 0, "UNKNOWN": 0}
+    # Severity ordering for picking the highest-impact finding per
+    # function. ERROR ranks above SAFE so an unverified function can
+    # never be reported as safe; ranked below LOW so a real low-signal
+    # finding still wins when the same function has both. Keep aligned
+    # with ``mcpscanner/core/result.py::get_highest_severity``.
+    severity_order = {
+        "HIGH": 5,
+        "MEDIUM": 4,
+        "LOW": 3,
+        "INFO": 2,
+        "ERROR": 1,
+        "SAFE": 0,
+        "UNKNOWN": 0,
+    }
     results: List[Dict[str, Any]] = []
     seen_keys: set = set()
 
@@ -1444,7 +1457,11 @@ async def main():
     )
     parser.add_argument(
         "--severity-filter",
-        choices=["all", "high", "unknown", "medium", "low", "safe"],
+        # ``error`` filters to verification-failure rows (LLM unavailable
+        # etc.) so operators can triage infrastructure issues separately
+        # from security findings. Keep aligned with the SeverityFilter
+        # enum in ``mcpscanner/core/models.py``.
+        choices=["all", "high", "unknown", "medium", "low", "info", "error", "safe"],
         default="all",
         help="Filter results by severity level (default: %(default)s)",
     )
@@ -2364,21 +2381,22 @@ async def main():
         else:
             output_format = OutputFormat.SUMMARY
 
-        # Determine severity filter
-        if args.severity_filter == "all":
-            severity_filter = SeverityFilter.ALL
-        elif args.severity_filter == "high":
-            severity_filter = SeverityFilter.HIGH
-        elif args.severity_filter == "unknown":
-            severity_filter = SeverityFilter.UNKNOWN
-        elif args.severity_filter == "medium":
-            severity_filter = SeverityFilter.MEDIUM
-        elif args.severity_filter == "low":
-            severity_filter = SeverityFilter.LOW
-        elif args.severity_filter == "safe":
-            severity_filter = SeverityFilter.SAFE
-        else:
-            severity_filter = SeverityFilter.ALL
+        # Determine severity filter. Keep this dispatch in sync with
+        # the ``--severity-filter`` argparse choices above and the
+        # SeverityFilter enum in ``mcpscanner/core/models.py``.
+        severity_filter_map = {
+            "all": SeverityFilter.ALL,
+            "high": SeverityFilter.HIGH,
+            "unknown": SeverityFilter.UNKNOWN,
+            "medium": SeverityFilter.MEDIUM,
+            "low": SeverityFilter.LOW,
+            "info": SeverityFilter.INFO,
+            "error": SeverityFilter.ERROR,
+            "safe": SeverityFilter.SAFE,
+        }
+        severity_filter = severity_filter_map.get(
+            args.severity_filter, SeverityFilter.ALL
+        )
 
         # Generate and display report
         formatted_output = formatter.format_output(

--- a/mcpscanner/core/analyzers/base.py
+++ b/mcpscanner/core/analyzers/base.py
@@ -213,7 +213,12 @@ class BaseAnalyzer(ABC):
         """Create a security finding with this analyzer's name and standardized format.
 
         Args:
-            severity: The severity level ("HIGH", "MEDIUM", "LOW", "INFO", "SAFE", "UNKNOWN").
+            severity: The severity level ("HIGH", "MEDIUM", "LOW", "INFO",
+                "SAFE", "ERROR", "UNKNOWN"). Use "ERROR" only for entries
+                where verification could not complete (e.g. LLM provider
+                unavailable); never use it as a fallback when the analyzer
+                successfully produced a result with an unmapped severity —
+                that case should remain "UNKNOWN".
             summary: Brief description of the security finding.
             threat_category: Standardized threat category.
             confidence: The confidence level ("HIGH", "MEDIUM", "LOW").

--- a/mcpscanner/core/analyzers/base.py
+++ b/mcpscanner/core/analyzers/base.py
@@ -30,7 +30,11 @@ class SecurityFinding:
     """Represents a single security finding from an analyzer.
 
     Attributes:
-        severity (str): The severity level: "HIGH", "MEDIUM", "LOW", or "INFO".
+        severity (str): The severity level: "HIGH", "MEDIUM", "LOW", "INFO",
+            "SAFE", "ERROR", or "UNKNOWN". "ERROR" is reserved for analyzer
+            failures where verification could not complete (e.g. LLM provider
+            unavailable); callers must NOT treat ERROR rows as evidence of
+            safety.
         summary (str): A summary description of the security finding.
         threat_category (str): Standardized threat category.
         analyzer (str): The name of the analyzer that found the security finding.
@@ -49,7 +53,11 @@ class SecurityFinding:
         """Initialize a new SecurityFinding instance.
 
         Args:
-            severity (str): The severity level ("HIGH", "MEDIUM", "LOW", "INFO", "SAFE", "UNKNOWN").
+            severity (str): The severity level ("HIGH", "MEDIUM", "LOW",
+                "INFO", "SAFE", "ERROR", "UNKNOWN"). "ERROR" indicates the
+                analyzer was unable to complete verification for this entry
+                (e.g. LLM provider failure) and the caller must distinguish
+                it from "SAFE", which is a positive verified-clean signal.
             summary (str): A summary description of the security finding.
             analyzer (str): The name of the analyzer that found the security finding.
             threat_category (str): Standardized threat category.
@@ -57,7 +65,9 @@ class SecurityFinding:
         """
         # Validate and normalize inputs
         self.severity = self._normalize_level(
-            severity, ["HIGH", "MEDIUM", "LOW", "INFO", "SAFE", "UNKNOWN"], "UNKNOWN"
+            severity,
+            ["HIGH", "MEDIUM", "LOW", "INFO", "SAFE", "ERROR", "UNKNOWN"],
+            "UNKNOWN",
         )
         self.summary = summary
         self.threat_category = threat_category

--- a/mcpscanner/core/analyzers/behavioral/alignment/__init__.py
+++ b/mcpscanner/core/analyzers/behavioral/alignment/__init__.py
@@ -29,7 +29,10 @@ All components use the 'alignment_' prefix to indicate they are part of
 the semantic alignment verification layer.
 """
 
-from .alignment_orchestrator import AlignmentOrchestrator
+from .alignment_orchestrator import (
+    LLM_UNAVAILABLE_KEY,
+    AlignmentOrchestrator,
+)
 from .alignment_prompt_builder import AlignmentPromptBuilder
 from .alignment_llm_client import AlignmentLLMClient
 from .alignment_response_validator import AlignmentResponseValidator
@@ -39,4 +42,10 @@ __all__ = [
     "AlignmentPromptBuilder",
     "AlignmentLLMClient",
     "AlignmentResponseValidator",
+    # Marker key on orchestrator result dicts that signals LLM
+    # verification could not complete for a function. SDK consumers
+    # that read raw orchestrator output (rather than going through
+    # BehavioralCodeAnalyzer's SecurityFinding wrapping) need this to
+    # distinguish "verified clean" from "couldn't verify".
+    "LLM_UNAVAILABLE_KEY",
 ]

--- a/mcpscanner/core/analyzers/behavioral/alignment/alignment_orchestrator.py
+++ b/mcpscanner/core/analyzers/behavioral/alignment/alignment_orchestrator.py
@@ -24,6 +24,24 @@ It coordinates the alignment verification process by:
 4. Creating security findings for mismatches
 
 This is the entry point for all alignment verification operations.
+
+Failure semantics
+-----------------
+The orchestrator distinguishes three outcomes per function:
+
+* **Mismatch detected** — returns ``(analysis_dict, func_context)`` where
+  ``analysis_dict`` describes the mismatch (no ``LLM_UNAVAILABLE_KEY`` set).
+* **Verified clean** — returns ``None``.
+* **Could not verify** — returns ``(sentinel_dict, func_context)`` where
+  ``sentinel_dict[LLM_UNAVAILABLE_KEY] is True``. This is the case when the
+  LLM provider failed (network error, model identifier invalid, throttling
+  past retry, prompt build crash, etc.). Callers MUST NOT collapse this
+  into the "verified clean" bucket; downstream analyzers map it to a
+  ``severity="ERROR"`` finding so operators can see what was unverified.
+
+Returning a sentinel rather than re-raising lets ``check_alignment_batch``
+report partial progress: a single bad function in a batch shouldn't drop
+the alignment results for its peers.
 """
 
 import logging
@@ -36,6 +54,37 @@ from .alignment_prompt_builder import AlignmentPromptBuilder
 from .alignment_llm_client import AlignmentLLMClient
 from .alignment_response_validator import AlignmentResponseValidator
 from .threat_vulnerability_classifier import ThreatVulnerabilityClassifier
+
+
+# Marker key on result dicts indicating that LLM verification could NOT
+# complete for a function. Callers (BehavioralCodeAnalyzer) detect this
+# via ``analysis.get(LLM_UNAVAILABLE_KEY)`` and emit a ``severity="ERROR"``
+# finding instead of treating the function as verified-clean. The leading
+# underscore signals "internal sentinel" so it doesn't collide with any
+# real LLM-returned field name.
+LLM_UNAVAILABLE_KEY = "_llm_unavailable"
+
+
+def _make_llm_unavailable_result(error: BaseException) -> Dict[str, Any]:
+    """Build a sentinel result for an unrecoverable per-function LLM failure.
+
+    The sentinel satisfies the orchestrator's ``Tuple[Dict, FunctionContext]``
+    return shape but is distinguishable from a real mismatch via
+    ``LLM_UNAVAILABLE_KEY``. ``mismatch_detected`` is set to False so any
+    legacy caller that branches on it still treats the entry as "not a
+    mismatch" — but proper callers should branch on ``LLM_UNAVAILABLE_KEY``
+    first to avoid losing the verification-failure signal.
+
+    The error message is truncated to keep findings.json artifacts small;
+    full traces still land in the analyzer log via ``exc_info=True``.
+    """
+    raw_message = str(error) if error is not None else ""
+    return {
+        LLM_UNAVAILABLE_KEY: True,
+        "mismatch_detected": False,
+        "error_type": type(error).__name__ if error is not None else "Unknown",
+        "error_message": raw_message[:500],
+    }
 
 
 class AlignmentOrchestrator:
@@ -94,7 +143,22 @@ class AlignmentOrchestrator:
             func_context: Complete function context with dataflow analysis
 
         Returns:
-            Tuple of (analysis_dict, func_context) if mismatch detected, None if aligned
+            One of three values:
+
+            * ``(analysis_dict, func_context)`` where ``analysis_dict`` does
+              NOT contain :data:`LLM_UNAVAILABLE_KEY` — a real mismatch was
+              detected.
+            * ``(sentinel_dict, func_context)`` where
+              ``sentinel_dict[LLM_UNAVAILABLE_KEY] is True`` — LLM
+              verification could not complete (provider error, invalid model
+              id, response validation failure, prompt build crash, etc.).
+              The caller MUST treat this as "unverified", not "clean".
+            * ``None`` — verification succeeded and no mismatch was detected.
+
+            Prior versions of this method returned ``None`` for both clean
+            and "couldn't verify" outcomes, which let LLM provider failures
+            silently masquerade as a clean bill of health when the caller
+            synthesised SAFE rows for missing mismatches.
         """
         self.stats["total_analyzed"] += 1
 
@@ -199,62 +263,95 @@ class AlignmentOrchestrator:
                 return None
 
         except Exception as e:
-            self.logger.error(f"Alignment check failed for {func_context.name}: {e}")
+            # Verification could not complete. Surface a sentinel so the
+            # caller can emit a `severity="ERROR"` finding instead of
+            # treating the function as verified-clean. We log with
+            # exc_info to preserve the full trace in the analyzer log even
+            # though the truncated message is what lands on the finding.
+            self.logger.error(
+                f"Alignment check failed for {func_context.name}: {e}",
+                exc_info=True,
+            )
             self.stats["skipped_error"] += 1
-            return None
+            return (_make_llm_unavailable_result(e), func_context)
 
     async def check_alignment_batch(
         self, func_contexts: List[FunctionContext], batch_size: int = 5
     ) -> List[Tuple[Dict[str, Any], FunctionContext]]:
         """Check alignment for multiple functions in batched LLM calls.
 
-        This method batches multiple functions into single LLM requests to reduce
-        API calls and improve scanning speed.
+        This method batches multiple functions into single LLM requests to
+        reduce API calls and improve scanning speed.
 
         Args:
             func_contexts: List of function contexts to analyze
             batch_size: Number of functions per LLM request (default: 5)
 
         Returns:
-            List of (analysis_dict, func_context) tuples for detected mismatches
+            List of ``(analysis_dict, func_context)`` tuples — one per
+            function that either tripped a mismatch OR could not be
+            verified. Verified-clean functions are NOT in the list (their
+            absence is the signal). Each entry is one of:
+
+            * Mismatch tuple — ``analysis_dict`` does not contain
+              :data:`LLM_UNAVAILABLE_KEY` and may include ``threat_name``,
+              ``severity``, etc.
+            * LLM-unavailable sentinel — ``analysis_dict[LLM_UNAVAILABLE_KEY]``
+              is True. The caller MUST emit a ``severity="ERROR"`` finding
+              for this entry instead of falling back to "no mismatch =
+              SAFE", which would mask the verification gap.
+
+            Prior versions of this method silently swallowed batch-level
+            exceptions and returned an empty list, which caused
+            ``BehavioralCodeAnalyzer`` to synthesise SAFE rows for every
+            function as if the LLM had cleared them. The new contract
+            propagates per-function verification failures so that bug is
+            no longer reachable.
         """
         results = []
-        
+
         # Process in batches
         for i in range(0, len(func_contexts), batch_size):
-            batch = func_contexts[i:i + batch_size]
+            batch = func_contexts[i : i + batch_size]
             self.logger.debug(f"Processing batch of {len(batch)} functions")
-            
+
             try:
                 # Build batched prompt
                 prompt = self.prompt_builder.build_batch_prompt(batch)
-                
+
                 # Query LLM
                 response = await self.llm_client.verify_alignment(prompt)
-                
+
                 # Parse batched response
-                batch_results = self.response_validator.validate_batch(response, len(batch))
-                
+                batch_results = self.response_validator.validate_batch(
+                    response, len(batch)
+                )
+
                 if not batch_results:
-                    self.logger.warning("Invalid batch response, falling back to individual analysis")
-                    # Fallback to individual analysis
+                    self.logger.warning(
+                        "Invalid batch response, falling back to individual analysis"
+                    )
+                    # Fall back to individual analysis. ``check_alignment``
+                    # now returns sentinel-or-mismatch-or-None, so we must
+                    # forward every non-None result (including sentinels)
+                    # rather than dropping them.
                     for func_context in batch:
                         result = await self.check_alignment(func_context)
-                        if result:
+                        if result is not None:
                             results.append(result)
                     continue
-                
+
                 # Process each result in the batch
                 for idx, result in enumerate(batch_results):
                     if idx >= len(batch):
                         break
-                    
+
                     func_context = batch[idx]
                     self.stats["total_analyzed"] += 1
-                    
+
                     if result and result.get("mismatch_detected"):
                         self.stats["mismatches_detected"] += 1
-                        
+
                         # Classify as threat or vulnerability
                         threat_name = result.get("threat_name", "")
                         if threat_name != "GENERAL DESCRIPTION-CODE MISMATCH":
@@ -264,34 +361,52 @@ class AlignmentOrchestrator:
                                     threat_name=threat_name or "UNKNOWN",
                                     severity=mapped_severity,
                                     summary=result.get("summary", ""),
-                                    description_claims=result.get("description_claims", ""),
+                                    description_claims=result.get(
+                                        "description_claims", ""
+                                    ),
                                     actual_behavior=result.get("actual_behavior", ""),
-                                    security_implications=result.get("security_implications", ""),
-                                    dataflow_evidence=result.get("dataflow_evidence", ""),
+                                    security_implications=result.get(
+                                        "security_implications", ""
+                                    ),
+                                    dataflow_evidence=result.get(
+                                        "dataflow_evidence", ""
+                                    ),
                                 )
                                 if classification:
-                                    result["threat_vulnerability_classification"] = classification["classification"]
+                                    result["threat_vulnerability_classification"] = (
+                                        classification["classification"]
+                                    )
                                 else:
-                                    result["threat_vulnerability_classification"] = "UNCLEAR"
+                                    result["threat_vulnerability_classification"] = (
+                                        "UNCLEAR"
+                                    )
                             except Exception as e:
                                 self.logger.error(f"Classification failed: {e}")
-                                result["threat_vulnerability_classification"] = "UNCLEAR"
-                        
+                                result["threat_vulnerability_classification"] = (
+                                    "UNCLEAR"
+                                )
+
                         results.append((result, func_context))
                     else:
                         self.stats["no_mismatch"] += 1
-                        
+
             except Exception as e:
-                self.logger.error(f"Batch analysis failed: {e}, falling back to individual")
-                # Fallback to individual analysis
+                # Whole batch failed (typically prompt build or LLM call).
+                # Fall back to per-function calls so peers are unaffected.
+                # ``check_alignment`` is exception-safe and now returns a
+                # sentinel rather than re-raising on its own failures, so
+                # we no longer need a defensive ``try/except: pass``
+                # around the call — that pattern was the silent-failure
+                # bug we are fixing here.
+                self.logger.error(
+                    f"Batch analysis failed: {e}, falling back to individual",
+                    exc_info=True,
+                )
                 for func_context in batch:
-                    try:
-                        result = await self.check_alignment(func_context)
-                        if result:
-                            results.append(result)
-                    except Exception:
-                        pass
-        
+                    result = await self.check_alignment(func_context)
+                    if result is not None:
+                        results.append(result)
+
         return results
 
     @staticmethod

--- a/mcpscanner/core/analyzers/behavioral/code_analyzer.py
+++ b/mcpscanner/core/analyzers/behavioral/code_analyzer.py
@@ -42,8 +42,7 @@ from ...static_analysis.interprocedural.treesitter_call_graph import (
     TreeSitterCallGraphAnalyzer,
 )
 from ..base import BaseAnalyzer, SecurityFinding
-from .alignment import AlignmentOrchestrator
-from .alignment.alignment_orchestrator import LLM_UNAVAILABLE_KEY
+from .alignment import LLM_UNAVAILABLE_KEY, AlignmentOrchestrator
 
 
 @dataclass(slots=True)
@@ -838,9 +837,14 @@ class BehavioralCodeAnalyzer(BaseAnalyzer):
         decorator_types = getattr(func_context, "decorator_types", None) or []
         func_name = getattr(func_context, "name", "unknown")
         # Truncate the message in the summary so finding artifacts stay
-        # human-readable. Full text is preserved in details.error_message
-        # (already truncated to 500 chars upstream by the orchestrator).
-        truncated = error_message if len(error_message) <= 200 else error_message[:200] + "..."
+        # human-readable, but keep enough room for typical Bedrock /
+        # provider error messages including the full model ARN
+        # (~140 chars by itself) plus a short prefix. 400 leaves
+        # headroom for the prefix without truncating the model
+        # identifier mid-string. Full text is preserved in
+        # details.error_message (already truncated to 500 chars upstream
+        # by the orchestrator).
+        truncated = error_message if len(error_message) <= 400 else error_message[:400] + "..."
         return SecurityFinding(
             severity="ERROR",
             summary=(

--- a/mcpscanner/core/analyzers/behavioral/code_analyzer.py
+++ b/mcpscanner/core/analyzers/behavioral/code_analyzer.py
@@ -43,6 +43,7 @@ from ...static_analysis.interprocedural.treesitter_call_graph import (
 )
 from ..base import BaseAnalyzer, SecurityFinding
 from .alignment import AlignmentOrchestrator
+from .alignment.alignment_orchestrator import LLM_UNAVAILABLE_KEY
 
 
 @dataclass(slots=True)
@@ -693,7 +694,7 @@ class BehavioralCodeAnalyzer(BaseAnalyzer):
                     func_contexts, batch_size=batch_size
                 )
                 for analysis, ctx in batch_results:
-                    finding = self._create_security_finding(analysis, ctx, file_path)
+                    finding = self._dispatch_finding(analysis, ctx, file_path)
                     if finding:
                         findings.append(finding)
             else:
@@ -723,22 +724,32 @@ class BehavioralCodeAnalyzer(BaseAnalyzer):
 
                     if result:
                         analysis, ctx = result
-                        finding = self._create_security_finding(analysis, ctx, file_path)
+                        finding = self._dispatch_finding(analysis, ctx, file_path)
                         if finding:
                             findings.append(finding)
 
             # Emit a SAFE SecurityFinding for every scanned function that
-            # didn't produce a concrete mismatch. This lifts safe-tool
+            # didn't already produce a finding. This lifts safe-tool
             # enumeration into the documented analyze() return contract
             # instead of forcing SDK callers to read the legacy
             # analyzed_functions side-channel attribute. Callers should
             # classify entries by finding.severity (SAFE vs HIGH/MEDIUM/
-            # LOW/INFO) rather than by len(findings)==0.
+            # LOW/INFO/ERROR) rather than by len(findings)==0.
+            #
+            # ERROR findings (severity="ERROR", details["llm_unavailable"]
+            # is True) are emitted by ``_dispatch_finding`` whenever the
+            # alignment orchestrator returns its LLM-unavailable sentinel
+            # for a function. Those functions appear in
+            # ``funcs_with_findings`` below, which is what suppresses the
+            # synthesized SAFE row for them — preserving the invariant
+            # that SAFE is reserved for "the LLM verified this function
+            # and found no mismatch", not for "we couldn't verify".
             #
             # Only synthesize SAFE rows when analysis completed without
-            # raising — if alignment_orchestrator throws and we fall
-            # through to the except block below, findings is partial and
-            # we MUST NOT claim the rest are safe (we just don't know).
+            # raising — if the orchestrator's outer machinery throws and
+            # we fall through to the except block below, findings is
+            # partial and we MUST NOT claim the rest are safe (we just
+            # don't know).
             funcs_with_findings = {
                 (f.details or {}).get("function_name")
                 for f in findings
@@ -783,6 +794,76 @@ class BehavioralCodeAnalyzer(BaseAnalyzer):
             self.logger.error(f"Analysis failed for {file_path}: {e}", exc_info=True)
 
         return findings
+
+    def _dispatch_finding(
+        self, analysis: Dict[str, Any], func_context, file_path: str
+    ) -> Optional[SecurityFinding]:
+        """Build a finding from an alignment-orchestrator result tuple.
+
+        Splits the two paths the orchestrator can return:
+
+        * ``analysis[LLM_UNAVAILABLE_KEY] is True`` — verification could
+          not complete; emit a ``severity="ERROR"`` finding so the row is
+          visible in artifacts and clearly distinguishable from
+          ``severity="SAFE"`` (verified clean). Skips the threat-mapping
+          path entirely because there is no real threat name.
+        * Otherwise — a real mismatch result; route through the existing
+          threat-mapping pipeline.
+
+        Returns ``None`` when the underlying creator returns ``None``
+        (e.g. unrecognised threat name on a real mismatch). The synthetic
+        SAFE row for that function is still suppressed in
+        ``_analyze_source_code``'s fallback loop because the dispatched
+        path always yields either a finding or a deliberate ``None``.
+        """
+        if analysis.get(LLM_UNAVAILABLE_KEY):
+            return self._create_llm_unavailable_finding(analysis, func_context, file_path)
+        return self._create_security_finding(analysis, func_context, file_path)
+
+    def _create_llm_unavailable_finding(
+        self, analysis: Dict[str, Any], func_context, file_path: str
+    ) -> SecurityFinding:
+        """Create a ``severity="ERROR"`` finding for an unverified function.
+
+        ERROR is distinct from SAFE in the SecurityFinding contract: SAFE
+        is a positive "LLM examined this function and found no mismatch"
+        signal, ERROR is "the LLM never returned a verdict for this
+        function so we have no evidence either way". Operators consuming
+        the findings.json artifact MUST NOT treat ERROR rows as evidence
+        of safety; they should re-run the scan after fixing the LLM
+        access path (model id, throttling, IAM, region, etc.).
+        """
+        error_type = analysis.get("error_type") or "Unknown"
+        error_message = (analysis.get("error_message") or "").strip()
+        decorator_types = getattr(func_context, "decorator_types", None) or []
+        func_name = getattr(func_context, "name", "unknown")
+        # Truncate the message in the summary so finding artifacts stay
+        # human-readable. Full text is preserved in details.error_message
+        # (already truncated to 500 chars upstream by the orchestrator).
+        truncated = error_message if len(error_message) <= 200 else error_message[:200] + "..."
+        return SecurityFinding(
+            severity="ERROR",
+            summary=(
+                f"LLM verification unavailable for {func_name}: "
+                f"{error_type}: {truncated}"
+            ),
+            threat_category="",
+            analyzer="Behavioral",
+            details={
+                "function_name": func_name,
+                "decorator_type": (
+                    decorator_types[0] if decorator_types else "unknown"
+                ),
+                "line_number": getattr(func_context, "line_number", 0),
+                "source_file": file_path,
+                # Marker so consumers can filter ERROR rows without
+                # relying on severity alone (other analyzers may also
+                # emit ERROR-severity findings in the future).
+                "llm_unavailable": True,
+                "error_type": error_type,
+                "error_message": error_message,
+            },
+        )
 
     def _create_security_finding(
         self, analysis: Dict[str, Any], func_context, file_path: str

--- a/mcpscanner/core/models.py
+++ b/mcpscanner/core/models.py
@@ -41,13 +41,22 @@ class OutputFormat(str, Enum):
 
 
 class SeverityFilter(str, Enum):
-    """Available severity filters."""
+    """Available severity filters.
+
+    ``ERROR`` corresponds to ``severity="ERROR"`` SecurityFinding rows
+    emitted when an analyzer was unable to complete verification (e.g.
+    LLM provider unreachable). It is exposed as a filter so operators
+    can list only verification failures via ``--severity=error`` to
+    triage infrastructure issues separately from security findings.
+    """
 
     ALL = "all"
     HIGH = "high"
     UNKNOWN = "unknown"
     MEDIUM = "medium"
     LOW = "low"
+    INFO = "info"
+    ERROR = "error"
     SAFE = "safe"
 
 

--- a/mcpscanner/core/report_generator.py
+++ b/mcpscanner/core/report_generator.py
@@ -569,13 +569,17 @@ class ReportGenerator:
             severities = [f.get("severity", "UNKNOWN") for f in findings.values()]
             highest_severity = get_highest_severity(severities)
 
-            # Use colored emojis based on severity
+            # Use colored emojis based on severity. ERROR uses a wrench
+            # because the row signals an analyzer-side problem operators
+            # need to fix (model id, throttling, IAM) rather than a
+            # tool-side risk to triage.
             severity_emojis = {
                 "HIGH": "🔴",
                 "UNKNOWN": "🟣",
                 "MEDIUM": "🟠",
                 "LOW": "🟡",
                 "INFO": "🔵",
+                "ERROR": "🛠️",
                 "SAFE": "🟢",
             }
             severity_icon = severity_emojis.get(highest_severity, "🟣")
@@ -689,14 +693,20 @@ class ReportGenerator:
         # confirmed concrete severity, so a tool with both UNKNOWN and any
         # concrete finding would have already been bucketed into the
         # concrete bucket; surfacing UNKNOWN-only items at the bottom keeps
-        # the eye on confirmed risk first.
-        severity_order = ["HIGH", "MEDIUM", "LOW", "INFO", "SAFE", "UNKNOWN"]
+        # the eye on confirmed risk first. ERROR goes between SAFE and
+        # UNKNOWN so verification failures (LLM unavailable etc.) get a
+        # dedicated section that operators can route to infra triage
+        # rather than security triage. Anything not in this list is
+        # silently skipped by the loop below; keeping it in sync with
+        # ``mcpscanner/core/result.py::get_highest_severity`` is required.
+        severity_order = ["HIGH", "MEDIUM", "LOW", "INFO", "SAFE", "ERROR", "UNKNOWN"]
         severity_emojis = {
             "HIGH": "🔴",
             "MEDIUM": "🟠",
             "LOW": "🟡",
             "INFO": "🔵",
             "SAFE": "🟢",
+            "ERROR": "🛠️",
             "UNKNOWN": "🟣",
         }
 
@@ -819,6 +829,7 @@ class ReportGenerator:
                 "MEDIUM": "🟠",
                 "LOW": "🟡",
                 "INFO": "🔵",
+                "ERROR": "🛠️",
                 "SAFE": "🟢",
             }
 
@@ -865,11 +876,19 @@ class ReportGenerator:
             "total_tools": len(self.scan_results),
             "safe_tools": 0,
             "unsafe_tools": 0,
+            # Severity counts include ERROR so verification failures
+            # (LLM unavailable etc.) are countable for operator alerts.
+            # INFO is also added here — historically missing from this
+            # particular dict, which silently dropped INFO findings
+            # from the get_statistics rollup; keeping it in sync with
+            # ``result.py::process_scan_results::severity_counts``.
             "severity_counts": {
                 "HIGH": 0,
                 "UNKNOWN": 0,
                 "MEDIUM": 0,
                 "LOW": 0,
+                "INFO": 0,
+                "ERROR": 0,
                 "SAFE": 0,
             },
             "analyzer_stats": {

--- a/mcpscanner/core/result.py
+++ b/mcpscanner/core/result.py
@@ -250,12 +250,17 @@ def process_scan_results(
     safe_tools = [r for r in results if r.is_safe]
     unsafe_tools = [r for r in results if not r.is_safe]
 
-    # Count findings by severity
+    # Count findings by severity. ERROR is included so operators can
+    # alarm on bursts of LLM-unavailable verification failures instead
+    # of having them silently dropped by the ``if severity in
+    # severity_counts`` guard below — that drop was the artifact-format
+    # echo of the silent-failure bug fixed by the ERROR-not-SAFE PR.
     severity_counts = {
         "HIGH": 0,
         "MEDIUM": 0,
         "LOW": 0,
         "INFO": 0,
+        "ERROR": 0,
         "SAFE": 0,
         "UNKNOWN": 0,
     }
@@ -392,7 +397,16 @@ def get_highest_severity(severities: List[str]) -> str:
     Severity model:
     - "UNKNOWN" represents "not yet analyzed" / "analyzer didn't run". It is the
       pre-analysis default and is *displaced* by any concrete severity
-      ("HIGH", "MEDIUM", "LOW", "INFO", "SAFE") produced by an analyzer.
+      ("HIGH", "MEDIUM", "LOW", "INFO", "ERROR", "SAFE") produced by an analyzer.
+    - "ERROR" represents "analyzer attempted verification but the verification
+      itself failed" (e.g. LLM provider unreachable, model id invalid). It is
+      ranked above SAFE so a tool with both ERROR and SAFE rows correctly rolls
+      up as ERROR — you cannot report a tool as clean if any function on it was
+      not verified. It is intentionally ranked below INFO so a real low-signal
+      finding still beats a transient infrastructure failure when both are
+      present on the same scope.
+    - "SAFE" is reserved for "verified clean" — never use it as a fallback when
+      verification didn't complete.
     - When concrete severities are present, the highest among them wins.
     - When the list is empty or contains only "UNKNOWN" entries, the result is
       "UNKNOWN" (nothing concrete to roll up).
@@ -404,10 +418,15 @@ def get_highest_severity(severities: List[str]) -> str:
         str: The highest severity level.
     """
     severity_order = {
-        "HIGH": 5,
-        "MEDIUM": 4,
-        "LOW": 3,
-        "INFO": 2,
+        "HIGH": 6,
+        "MEDIUM": 5,
+        "LOW": 4,
+        "INFO": 3,
+        # ERROR ranks above SAFE so [ERROR, SAFE] rolls up as ERROR.
+        # See codeguard-0-logging: ERROR-severity events must remain
+        # visible in aggregated dashboards rather than being silently
+        # collapsed into a clean-bill-of-health bucket.
+        "ERROR": 2,
         "SAFE": 1,
     }
 

--- a/tests/behavioral/test_llm_unavailable_does_not_emit_safe.py
+++ b/tests/behavioral/test_llm_unavailable_does_not_emit_safe.py
@@ -1,0 +1,377 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the LLM-unavailable / silent-failure bug.
+
+Background
+----------
+Prior to the ``LLM_UNAVAILABLE_KEY`` sentinel work, ``AlignmentOrchestrator``
+swallowed exceptions from ``AlignmentLLMClient.verify_alignment`` in two
+places — ``check_alignment`` returned ``None`` on any failure, and
+``check_alignment_batch`` had a bare ``except Exception: pass`` around its
+fallback path. ``BehavioralCodeAnalyzer`` then synthesised a SAFE row for
+every function the orchestrator didn't return a finding for, conflating
+"verified clean" with "couldn't verify". Operators saw all-SAFE findings
+artifacts even when the Bedrock model id was invalid or the provider was
+unreachable.
+
+These tests lock the new contract:
+
+1. ``check_alignment`` returns a ``(sentinel, ctx)`` tuple — not ``None``
+   — when ``verify_alignment`` raises.
+2. ``check_alignment_batch`` emits one sentinel per function in the batch
+   when the batch path fails, instead of dropping the batch silently.
+3. End-to-end: ``BehavioralCodeAnalyzer.analyze`` returns ``severity="ERROR"``
+   findings (one per function) and zero ``severity="SAFE"`` findings when
+   the LLM provider is unreachable.
+"""
+
+import os
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcpscanner.config import Config
+from mcpscanner.core.analyzers.base import SecurityFinding
+from mcpscanner.core.analyzers.behavioral.alignment.alignment_orchestrator import (
+    LLM_UNAVAILABLE_KEY,
+    AlignmentOrchestrator,
+)
+from mcpscanner.core.analyzers.behavioral.code_analyzer import BehavioralCodeAnalyzer
+
+
+_TWO_TOOL_MCP_SOURCE = '''
+import mcp
+
+@mcp.tool()
+def echo(text: str) -> str:
+    """Return the provided text unchanged."""
+    return text
+
+@mcp.tool()
+def add(a: float, b: float) -> float:
+    """Return the sum of two finite numbers."""
+    return a + b
+'''
+
+
+def _func_context(name: str, line_number: int) -> MagicMock:
+    """Build a minimal FunctionContext stub for orchestrator-level tests.
+
+    The orchestrator only reads ``name``, ``line_number``, and the
+    ``decorator_types`` list when constructing log messages and stats
+    keys, so a MagicMock with those attributes set is sufficient. Using
+    a real ``FunctionContext`` would force the test to also build all
+    the dataflow-analysis fields the prompt builder expects, which is
+    out of scope for a verification-failure regression test.
+    """
+    fc = MagicMock()
+    fc.name = name
+    fc.line_number = line_number
+    fc.decorator_types = ["mcp.tool"]
+    return fc
+
+
+@pytest.fixture
+def orchestrator() -> AlignmentOrchestrator:
+    """Build an AlignmentOrchestrator wired to a stub LLM client.
+
+    Uses ``Config(llm_provider_api_key="test-key")`` because the
+    constructor enforces an API key for non-Bedrock providers. The
+    actual LLM call site is patched in each test, so the key value is
+    never used.
+    """
+    return AlignmentOrchestrator(Config(llm_provider_api_key="test-key"))
+
+
+class TestCheckAlignmentReturnsSentinelOnLLMFailure:
+    """``check_alignment`` must surface a sentinel — not ``None`` — when
+    LLM verification fails. ``None`` is reserved for "verified clean".
+    """
+
+    @pytest.mark.asyncio
+    async def test_runtime_error_from_llm_yields_sentinel_tuple(
+        self, orchestrator: AlignmentOrchestrator
+    ) -> None:
+        # Patch the inner LLM client so the orchestrator's per-step
+        # try/except machinery is exercised (it wraps verify_alignment
+        # with its own logging + raise pattern).
+        ctx = _func_context("echo", line_number=4)
+
+        async def _boom(_prompt: str) -> str:
+            raise RuntimeError("simulated bedrock outage")
+
+        # The prompt builder runs first; mock it out so the test only
+        # exercises the LLM-call failure path.
+        with patch.object(
+            orchestrator.prompt_builder, "build_prompt", return_value="<prompt>"
+        ), patch.object(
+            orchestrator.llm_client,
+            "verify_alignment",
+            new=AsyncMock(side_effect=_boom),
+        ):
+            result = await orchestrator.check_alignment(ctx)
+
+        assert result is not None, (
+            "check_alignment must NOT return None when LLM verification "
+            "fails — None is reserved for 'verified clean' and would "
+            "let downstream collapse the failure into SAFE."
+        )
+        analysis, returned_ctx = result
+        assert returned_ctx is ctx
+        assert analysis.get(LLM_UNAVAILABLE_KEY) is True, (
+            f"sentinel marker missing from analysis dict: {analysis}"
+        )
+        assert analysis.get("error_type") == "RuntimeError"
+        assert "simulated bedrock outage" in analysis.get("error_message", "")
+        # The skipped_error stat must increment so operators can see the
+        # gap from get_statistics().
+        assert orchestrator.stats["skipped_error"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_clean_verification_still_returns_none(
+        self, orchestrator: AlignmentOrchestrator
+    ) -> None:
+        """Negative control: when verification succeeds and finds no
+        mismatch, ``check_alignment`` must still return ``None``. Only
+        actual failures should yield the sentinel — a healthy LLM that
+        says 'no mismatch' is the existing 'verified clean' signal.
+        """
+        ctx = _func_context("echo", line_number=4)
+        with patch.object(
+            orchestrator.prompt_builder, "build_prompt", return_value="<prompt>"
+        ), patch.object(
+            orchestrator.llm_client,
+            "verify_alignment",
+            new=AsyncMock(return_value="<llm-response>"),
+        ), patch.object(
+            orchestrator.response_validator,
+            "validate",
+            return_value={"mismatch_detected": False},
+        ):
+            result = await orchestrator.check_alignment(ctx)
+
+        assert result is None, (
+            f"verified-clean path must keep returning None, got {result!r}"
+        )
+
+
+class TestCheckAlignmentBatchEmitsSentinelOnFailure:
+    """``check_alignment_batch`` must propagate sentinels for each
+    function in a failed batch, instead of swallowing the exception.
+    """
+
+    @pytest.mark.asyncio
+    async def test_whole_batch_failure_emits_one_sentinel_per_function(
+        self, orchestrator: AlignmentOrchestrator
+    ) -> None:
+        contexts = [_func_context(f"tool_{i}", i + 1) for i in range(3)]
+
+        async def _boom(_prompt: str) -> str:
+            raise RuntimeError("simulated llm outage")
+
+        # Both the batched and the per-function fallback path must
+        # observe the same LLM failure so we know the orchestrator
+        # doesn't fall back into a different code path on the second
+        # call. Patching ``verify_alignment`` covers both because
+        # check_alignment also calls it during fallback.
+        with patch.object(
+            orchestrator.prompt_builder, "build_batch_prompt", return_value="<batch>"
+        ), patch.object(
+            orchestrator.prompt_builder, "build_prompt", return_value="<single>"
+        ), patch.object(
+            orchestrator.llm_client,
+            "verify_alignment",
+            new=AsyncMock(side_effect=_boom),
+        ):
+            results = await orchestrator.check_alignment_batch(contexts, batch_size=5)
+
+        assert len(results) == len(contexts), (
+            f"expected one sentinel per function, got {len(results)} for "
+            f"{len(contexts)} input contexts"
+        )
+        for analysis, returned_ctx in results:
+            assert analysis.get(LLM_UNAVAILABLE_KEY) is True, (
+                f"every result tuple must carry the LLM_UNAVAILABLE_KEY "
+                f"sentinel; got analysis={analysis}"
+            )
+            assert returned_ctx in contexts
+
+
+class TestBehavioralCodeAnalyzerEmitsErrorNotSafe:
+    """End-to-end regression: when the LLM provider is unreachable,
+    ``BehavioralCodeAnalyzer.analyze`` must emit ``severity="ERROR"``
+    rows for every scanned function and zero ``severity="SAFE"`` rows.
+    This is the exact bug the user reported: the prior implementation
+    silently emitted SAFE for every function on Bedrock validation
+    failures, producing false-negative findings artifacts.
+    """
+
+    @pytest.mark.asyncio
+    async def test_llm_unavailable_yields_error_findings_no_safe_rows(
+        self,
+    ) -> None:
+        config = Config(llm_provider_api_key="test-key")
+        analyzer = BehavioralCodeAnalyzer(config)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".py", delete=False
+        ) as f:
+            f.write(_TWO_TOOL_MCP_SOURCE)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            # Patch at the AlignmentLLMClient level so the test
+            # exercises the full chain: orchestrator's batched call
+            # raises -> per-function fallback also raises -> sentinels
+            # propagate through check_alignment_batch -> code_analyzer's
+            # _dispatch_finding routes them to _create_llm_unavailable_finding
+            # -> SecurityFinding(severity="ERROR") emitted.
+            async def _boom(_prompt: str) -> str:
+                raise RuntimeError(
+                    "ValidationException: The provided model identifier "
+                    "is invalid"
+                )
+
+            with patch.object(
+                analyzer.alignment_orchestrator.llm_client,
+                "verify_alignment",
+                new=AsyncMock(side_effect=_boom),
+            ):
+                findings = await analyzer.analyze(
+                    temp_path, {"file_path": temp_path}
+                )
+        finally:
+            os.unlink(temp_path)
+
+        assert isinstance(findings, list)
+        assert all(isinstance(f, SecurityFinding) for f in findings)
+
+        # The exact bug regression assertion: zero SAFE rows when the
+        # LLM was unreachable. Previously this would have been 2.
+        safe_findings = [f for f in findings if f.severity == "SAFE"]
+        assert len(safe_findings) == 0, (
+            "BehavioralCodeAnalyzer must NOT emit SAFE findings when "
+            "the LLM provider is unreachable; SAFE means 'verified "
+            "clean' and the LLM never returned a verdict. Got SAFE "
+            f"findings: {[(f.summary, f.details) for f in safe_findings]}"
+        )
+
+        error_findings = [f for f in findings if f.severity == "ERROR"]
+        assert len(error_findings) == 2, (
+            "expected one ERROR finding per scanned tool (echo, add); "
+            f"got {len(error_findings)}: "
+            f"{[(f.severity, f.summary) for f in error_findings]}"
+        )
+
+        # Each ERROR row must be self-describing: function_name +
+        # source_file + llm_unavailable=True so consumers can filter.
+        names = sorted((f.details or {}).get("function_name") for f in error_findings)
+        assert names == ["add", "echo"], names
+        for f in error_findings:
+            d = f.details or {}
+            assert d.get("source_file") == temp_path
+            assert d.get("llm_unavailable") is True, (
+                "ERROR finding must mark details.llm_unavailable=True so "
+                "consumers can distinguish LLM-availability errors from "
+                "other future ERROR-severity sources"
+            )
+            assert d.get("error_type") == "RuntimeError"
+            assert "ValidationException" in d.get("error_message", ""), (
+                "the original Bedrock error message must survive into "
+                "details.error_message so operators can debug without "
+                "re-running with logging enabled"
+            )
+            # threat_category empty so ERROR rows don't pollute
+            # downstream threat-name aggregates.
+            assert f.threat_category == ""
+
+    @pytest.mark.asyncio
+    async def test_partial_llm_failure_does_not_corrupt_safe_rows_for_peers(
+        self,
+    ) -> None:
+        """When the orchestrator returns a sentinel for one function and
+        nothing for another (verified clean), the analyzer must emit
+        exactly one ERROR row and one SAFE row — never an ERROR row that
+        masquerades as SAFE for the unverified function.
+        """
+        config = Config(llm_provider_api_key="test-key")
+        analyzer = BehavioralCodeAnalyzer(config)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".py", delete=False
+        ) as f:
+            f.write(_TWO_TOOL_MCP_SOURCE)
+            f.flush()
+            temp_path = f.name
+
+        try:
+            captured_contexts: list = []
+
+            async def _capture_then_partial(contexts, batch_size=5):
+                # Mirror the new contract: return a sentinel for the
+                # first function and nothing for the second (verified
+                # clean). The first arg in tuple is the analysis dict.
+                captured_contexts.extend(contexts)
+                return [
+                    (
+                        {
+                            LLM_UNAVAILABLE_KEY: True,
+                            "mismatch_detected": False,
+                            "error_type": "RuntimeError",
+                            "error_message": "simulated outage",
+                        },
+                        contexts[0],
+                    ),
+                ]
+
+            with patch.object(
+                analyzer.alignment_orchestrator,
+                "check_alignment_batch",
+                new=AsyncMock(side_effect=_capture_then_partial),
+            ):
+                findings = await analyzer.analyze(
+                    temp_path, {"file_path": temp_path}
+                )
+        finally:
+            os.unlink(temp_path)
+
+        assert len(captured_contexts) == 2, (
+            "sanity: both tools should be sent through check_alignment_batch"
+        )
+
+        error_findings = [f for f in findings if f.severity == "ERROR"]
+        safe_findings = [f for f in findings if f.severity == "SAFE"]
+
+        assert len(error_findings) == 1, (
+            f"expected exactly one ERROR finding (for the unverified "
+            f"function); got {len(error_findings)}"
+        )
+        assert len(safe_findings) == 1, (
+            f"expected exactly one SAFE finding (for the peer that the "
+            f"LLM cleared); got {len(safe_findings)}"
+        )
+
+        # ERROR and SAFE must be for DIFFERENT functions. Otherwise
+        # we'd have double-counted, which is itself a contract violation.
+        error_func = (error_findings[0].details or {}).get("function_name")
+        safe_func = (safe_findings[0].details or {}).get("function_name")
+        assert error_func != safe_func, (
+            f"ERROR and SAFE rows must cover disjoint functions; both "
+            f"named {error_func}"
+        )

--- a/tests/test_severity_rollup.py
+++ b/tests/test_severity_rollup.py
@@ -112,10 +112,231 @@ def test_post_analysis_rollup_is_never_unknown_when_anything_concrete() -> None:
     analyzer produced a concrete severity. Only fully-unknown input rolls
     up to UNKNOWN.
     """
-    concrete_only = ["HIGH", "MEDIUM", "LOW", "INFO", "SAFE"]
+    concrete_only = ["HIGH", "MEDIUM", "LOW", "INFO", "ERROR", "SAFE"]
     for sev in concrete_only:
         assert get_highest_severity([sev]) != "UNKNOWN"
         assert get_highest_severity([sev, "UNKNOWN"]) != "UNKNOWN"
 
     assert get_highest_severity([]) == "UNKNOWN"
     assert get_highest_severity(["UNKNOWN", "UNKNOWN"]) == "UNKNOWN"
+
+
+# -----------------------------------------------------------------------
+# ERROR severity (verification-failure) contract tests
+# -----------------------------------------------------------------------
+#
+# ERROR is the sentinel emitted when an analyzer attempted verification
+# but the verification path itself failed (e.g. LLM provider unreachable,
+# Bedrock model id invalid, throttled past retry). It is semantically
+# distinct from UNKNOWN ("not yet analyzed") and from SAFE ("verified
+# clean"). The rollup must treat it as concrete (so it displaces
+# UNKNOWN), rank it above SAFE (so a tool with both ERROR and SAFE rows
+# is reported as ERROR — you cannot claim a tool is clean if any
+# function on it was unverified), and rank it below the real triage
+# severities INFO/LOW/MEDIUM/HIGH (so a real low-signal finding still
+# wins when both are present on the same scope).
+
+
+@pytest.mark.parametrize(
+    "severities,expected",
+    [
+        # ERROR alone is concrete.
+        (["ERROR"], "ERROR"),
+        # ERROR displaces UNKNOWN, just like every other concrete severity.
+        (["ERROR", "UNKNOWN"], "ERROR"),
+        (["UNKNOWN", "ERROR"], "ERROR"),
+        # ERROR ranks above SAFE: a tool with both unverified and clean
+        # functions is NOT clean.
+        (["ERROR", "SAFE"], "ERROR"),
+        (["SAFE", "ERROR"], "ERROR"),
+        # ERROR ranks below the real triage severities.
+        (["ERROR", "INFO"], "INFO"),
+        (["ERROR", "LOW"], "LOW"),
+        (["ERROR", "MEDIUM"], "MEDIUM"),
+        (["ERROR", "HIGH"], "HIGH"),
+        # Case-insensitive.
+        (["error"], "ERROR"),
+        (["error", "safe"], "ERROR"),
+        (["error", "high"], "HIGH"),
+        # Mixed with UNKNOWN: the concrete ERROR still wins.
+        (["UNKNOWN", "ERROR", "UNKNOWN"], "ERROR"),
+    ],
+)
+def test_error_severity_rollup(severities: List[str], expected: str) -> None:
+    """Pin the ERROR severity ranking. See module-level comment above."""
+    assert get_highest_severity(severities) == expected
+
+
+def test_error_does_not_collapse_into_unknown() -> None:
+    """Regression: prior to the ERROR-not-SAFE PR completion, ERROR was
+    not in ``severity_order`` so ``get_highest_severity(["ERROR"])`` would
+    fall through to ``return "UNKNOWN"``. That collapse erased the entire
+    point of emitting ERROR severity rows from BehavioralCodeAnalyzer at
+    the artifact-format layer.
+    """
+    assert get_highest_severity(["ERROR"]) == "ERROR"
+    # And any list that contains ERROR plus only UNKNOWNs must never
+    # roll up as UNKNOWN — that would silently re-bucket verification
+    # failures alongside "analyzer didn't run".
+    assert get_highest_severity(["ERROR", "UNKNOWN"]) == "ERROR"
+    assert get_highest_severity(["UNKNOWN", "ERROR"]) == "ERROR"
+
+
+def test_error_does_not_get_reported_as_clean() -> None:
+    """Regression: ERROR must NEVER roll up as SAFE. A tool with both an
+    unverified function (ERROR) and a clean function (SAFE) cannot be
+    advertised to operators as a clean tool — you cannot certify what
+    you didn't verify. This test pins that invariant directly.
+    """
+    rollup = get_highest_severity(["ERROR", "SAFE"])
+    assert rollup != "SAFE", (
+        f"[ERROR, SAFE] rolled up as {rollup!r}; this would let a partial "
+        "verification failure masquerade as a clean tool — re-introducing "
+        "the original silent-failure bug at the per-tool aggregation level."
+    )
+    assert rollup == "ERROR"
+
+
+# -----------------------------------------------------------------------
+# process_scan_results / report_generator counts include ERROR
+# -----------------------------------------------------------------------
+
+
+def test_process_scan_results_counts_error_findings() -> None:
+    """``process_scan_results`` must include ERROR in its severity_counts
+    dict so verification failures are countable in summary stats. The
+    historical bug was the ``if severity in severity_counts`` guard
+    dropping ERROR entries on the floor.
+    """
+    from mcpscanner.config.constants import SeverityLevel  # noqa: F401
+    from mcpscanner.core.analyzers.base import SecurityFinding
+    from mcpscanner.core.result import ToolScanResult, process_scan_results
+
+    findings = [
+        SecurityFinding(
+            severity="ERROR",
+            summary="LLM verification unavailable for echo: RuntimeError: simulated",
+            threat_category="",
+            analyzer="Behavioral",
+            details={"function_name": "echo", "llm_unavailable": True},
+        ),
+        SecurityFinding(
+            severity="HIGH",
+            summary="real mismatch",
+            threat_category="DATA EXFILTRATION",
+            analyzer="Behavioral",
+            details={"function_name": "leaky"},
+        ),
+    ]
+    result = ToolScanResult(
+        tool_name="t1",
+        tool_description="d",
+        status="completed",
+        analyzers=["Behavioral"],
+        findings=findings,
+    )
+    summary = process_scan_results([result])
+
+    counts = summary["severity_counts"]
+    assert "ERROR" in counts, (
+        "process_scan_results.severity_counts must enumerate ERROR; "
+        "missing ERROR key drops verification-failure counts on the "
+        "floor via the `if severity in severity_counts` guard."
+    )
+    assert counts["ERROR"] == 1
+    assert counts["HIGH"] == 1
+
+
+def test_report_generator_statistics_count_error() -> None:
+    """``ReportGenerator.get_statistics`` exposes severity_counts to
+    callers building dashboards / alerts. Missing ERROR there silently
+    drops the count, so we lock the dict shape.
+    """
+    from mcpscanner.core.report_generator import ReportGenerator
+
+    scan_data = {
+        "scan_results": [
+            {
+                "tool_name": "t1",
+                "is_safe": False,
+                "findings": {
+                    "behavioral_analyzer": {
+                        "severity": "ERROR",
+                        "total_findings": 1,
+                    },
+                },
+            },
+            {
+                "tool_name": "t2",
+                "is_safe": False,
+                "findings": {
+                    "behavioral_analyzer": {
+                        "severity": "ERROR",
+                        "total_findings": 2,
+                    },
+                },
+            },
+        ]
+    }
+    rg = ReportGenerator(scan_data)
+    stats = rg.get_statistics()
+    counts = stats["severity_counts"]
+
+    assert "ERROR" in counts, (
+        "ReportGenerator.get_statistics severity_counts must include "
+        "ERROR; otherwise verification-failure rows are silently dropped "
+        "from the dashboard rollup."
+    )
+    assert counts["ERROR"] == 2
+
+
+def test_report_generator_markdown_renders_error_section() -> None:
+    """The grouped markdown report iterates a hardcoded ``severity_order``
+    list. ERROR must be in that list, otherwise its rows are silently
+    skipped in the rendered output and operators reading the markdown
+    artifact see no indication that the LLM was unreachable.
+    """
+    from mcpscanner.core.models import SeverityFilter
+    from mcpscanner.core.report_generator import ReportGenerator
+
+    results = [
+        {
+            "tool_name": "ht",
+            "is_safe": False,
+            "findings": {
+                "behavioral_analyzer": {
+                    "severity": "HIGH",
+                    "threat_summary": "real mismatch",
+                    "total_findings": 1,
+                }
+            },
+        },
+        {
+            "tool_name": "et",
+            "is_safe": False,
+            "findings": {
+                "behavioral_analyzer": {
+                    "severity": "ERROR",
+                    "threat_summary": "LLM unavailable",
+                    "total_findings": 1,
+                }
+            },
+        },
+    ]
+    rg = ReportGenerator({"scan_results": results})
+    output = rg._format_by_severity(results, SeverityFilter.ALL)  # type: ignore[attr-defined]
+
+    assert "ERROR SEVERITY" in output, (
+        "Markdown report must surface an ERROR SEVERITY section; missing "
+        "it means verification-failure rows are invisible to operators "
+        "reading findings.md."
+    )
+    assert "et" in output, "tool name from the ERROR group must be rendered"
+    # ERROR section has to render AFTER the security buckets so operators
+    # triage real risk first; pin that ordering.
+    assert output.index("HIGH SEVERITY") < output.index("ERROR SEVERITY")
+    assert "LLM unavailable" in output, (
+        "threat_summary from the ERROR finding must reach the markdown "
+        "output so operators can see what failed without opening the "
+        "raw JSON artifact"
+    )


### PR DESCRIPTION
`AlignmentOrchestrator.check_alignment_batch` had a bare `except Exception: pass` around its per-function fallback path, and `check_alignment` returned `None` for both "verified clean" and "couldn't verify" outcomes. Combined with `BehavioralCodeAnalyzer`'s SAFE-row synthesis (added in #175), any LLM-side failure - invalid Bedrock model id, throttling past retry, network outage, etc. - silently produced `severity="SAFE"` rows for every scanned function. Operators reading findings.json artifacts had no signal that the LLM never returned a verdict; they saw all-SAFE and assumed clean.

This commit replaces silent failure with an explicit per-function sentinel:

* Introduces `LLM_UNAVAILABLE_KEY`. `check_alignment` now returns `(sentinel_dict, ctx)` on failure instead of `None`; `None` stays reserved for the verified-clean path.
* `check_alignment_batch` propagates one sentinel per function in a failed batch instead of dropping the batch. The defensive `try: ... except Exception: pass` around the fallback is gone - `check_alignment` is now exception-safe at its own boundary.
* `BehavioralCodeAnalyzer._dispatch_finding` routes sentinels to a new `_create_llm_unavailable_finding` that emits `severity="ERROR"` with `details["llm_unavailable"]=True`. ERROR is added to the `SecurityFinding` valid-severity set (was being silently coerced to `UNKNOWN`).
* The SAFE-fallback synthesis loop already keys off `details["function_name"]`, so functions that received an ERROR finding are naturally excluded - preserving the invariant that SAFE means "LLM verified this and found no mismatch", never "we couldn't reach the LLM".

Regression test (`tests/behavioral/test_llm_unavailable_does_not_emit_safe.py`) locks the contract: when `AlignmentLLMClient.verify_alignment` raises, `analyze()` emits one ERROR finding per scanned tool and zero SAFE findings. Also covers the orchestrator-level unit tests for the sentinel surface and a partial-failure mixed case.

Full behavioral suite (84 tests) and first-party test suite (823 tests, 7 skipped) pass with no regressions.