### PR TITLE
fix: remove invalid timeout checks from readiness analyzer (HEUR-001, HEUR-002)

### DIFF
--- a/mcpscanner/core/analyzers/readiness/readiness_analyzer.py
+++ b/mcpscanner/core/analyzers/readiness/readiness_analyzer.py
@@ -23,11 +23,7 @@ heuristic checks and optional OPA policy evaluation.
 This analyzer focuses on operational reliability, NOT security vulnerabilities.
 It detects issues like missing timeouts, unsafe retry loops, and silent failures.
 
-Implements 20 core heuristic rules (HEUR-001 through HEUR-020):
-
-Timeout Guards (HEUR-001, HEUR-002):
-- Missing timeout configuration
-- Timeout values too long (>5 minutes)
+Implements 18 core heuristic rules (HEUR-003 through HEUR-020):
 
 Retry Configuration (HEUR-003, HEUR-004, HEUR-005):
 - No retry limit defined
@@ -262,8 +258,10 @@ class ReadinessAnalyzer(BaseAnalyzer):
         findings: List[SecurityFinding] = []
 
         # Timeout Guards
-        findings.extend(self._check_missing_timeout(tool_def, tool_name))
-        findings.extend(self._check_timeout_too_long(tool_def, tool_name))
+        # Note: HEUR-001 and HEUR-002 (timeout checks) have been removed.
+        # The MCP Tool specification does not define a timeout field on tools.
+        # Timeout configuration is an implementation concern, not a tool schema concern.
+        # See: https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool
 
         # Retry Configuration
         findings.extend(self._check_no_retry_limit(tool_def, tool_name))
@@ -366,86 +364,6 @@ class ReadinessAnalyzer(BaseAnalyzer):
             deduction = self.SEVERITY_DEDUCTIONS.get(finding.severity, 0)
             score -= deduction
         return max(0, score)
-
-    # ===================================================================
-    # HEUR-001: Missing timeout (HIGH)
-    # ===================================================================
-    def _check_missing_timeout(
-        self, tool_def: Dict[str, Any], tool_name: str
-    ) -> List[SecurityFinding]:
-        """HEUR-001: Check for missing timeout configuration."""
-        findings: List[SecurityFinding] = []
-
-        timeout_fields = ["timeout", "timeoutMs", "timeout_ms", "timeoutSeconds"]
-        has_timeout = any(field in tool_def for field in timeout_fields)
-
-        # Also check nested config
-        config = tool_def.get("config", {})
-        has_timeout = has_timeout or any(field in config for field in timeout_fields)
-
-        if not has_timeout:
-            findings.append(
-                self.create_security_finding(
-                    severity="HIGH",
-                    summary=(
-                        f"Tool '{tool_name}' does not specify a timeout. "
-                        "Operations may hang indefinitely if external services "
-                        "become unresponsive."
-                    ),
-                    threat_category="MISSING_TIMEOUT_GUARD",
-                    details={
-                        "tool_name": tool_name,
-                        "rule_id": "HEUR-001",
-                        "location": f"tool.{tool_name}",
-                        "recommendation": (
-                            "Add a 'timeout' or 'timeoutMs' field with a reasonable "
-                            "value (e.g., 30000 for 30 seconds)"
-                        ),
-                    },
-                )
-            )
-
-        return findings
-
-    # ===================================================================
-    # HEUR-002: Timeout too long (MEDIUM)
-    # ===================================================================
-    def _check_timeout_too_long(
-        self, tool_def: Dict[str, Any], tool_name: str
-    ) -> List[SecurityFinding]:
-        """HEUR-002: Check if timeout is greater than 300000ms (5 minutes)."""
-        findings: List[SecurityFinding] = []
-
-        timeout_fields = ["timeout", "timeoutMs", "timeout_ms"]
-        config = tool_def.get("config", {})
-
-        for field in timeout_fields:
-            timeout_value = tool_def.get(field) or config.get(field)
-            if timeout_value is not None and timeout_value > 300000:
-                findings.append(
-                    self.create_security_finding(
-                        severity="MEDIUM",
-                        summary=(
-                            f"Tool '{tool_name}' has {field}={timeout_value}ms "
-                            "(over 5 minutes). Long timeouts can cause extended hangs "
-                            "and poor user experience."
-                        ),
-                        threat_category="MISSING_TIMEOUT_GUARD",
-                        details={
-                            "tool_name": tool_name,
-                            "rule_id": "HEUR-002",
-                            "location": f"tool.{tool_name}.{field}",
-                            "field": field,
-                            "value": timeout_value,
-                            "recommendation": (
-                                "Consider reducing timeout to 30-60 seconds "
-                                "for better responsiveness"
-                            ),
-                        },
-                    )
-                )
-
-        return findings
 
     # ===================================================================
     # HEUR-003: No retry limit (MEDIUM)

--- a/tests/readiness/test_readiness_analyzer.py
+++ b/tests/readiness/test_readiness_analyzer.py
@@ -16,8 +16,10 @@
 
 """Unit tests for ReadinessAnalyzer.
 
-Tests all 20 heuristic rules (HEUR-001 through HEUR-020) for production
-readiness analysis of MCP tools.
+Tests all 18 core heuristic rules (HEUR-003 through HEUR-020) for production
+readiness analysis of MCP tools. HEUR-001 and HEUR-002 were removed because
+they checked for non-standard timeout fields that don't exist in the MCP
+Tool specification.
 """
 
 import json
@@ -70,102 +72,6 @@ class TestReadinessAnalyzerInitialization:
         )
         assert analyzer.max_capabilities == 5
         assert analyzer.min_description_length == 50
-
-
-class TestHEUR001MissingTimeout:
-    """Tests for HEUR-001: Missing timeout."""
-
-    @pytest.mark.asyncio
-    async def test_missing_timeout_triggers_finding(self):
-        """Tool without timeout should trigger HIGH finding."""
-        analyzer = ReadinessAnalyzer()
-        tool_def = {
-            "name": "test_tool",
-            "description": "A test tool that does something useful",
-        }
-        content = json.dumps(tool_def)
-        context = {"tool_name": "test_tool"}
-
-        findings = await analyzer.analyze(content, context)
-
-        finding = find_finding_by_rule(findings, "HEUR-001")
-        assert finding is not None
-        assert finding.severity == "HIGH"
-        assert finding.threat_category == "MISSING_TIMEOUT_GUARD"
-
-    @pytest.mark.asyncio
-    async def test_with_timeout_no_finding(self):
-        """Tool with timeout should not trigger HEUR-001."""
-        analyzer = ReadinessAnalyzer()
-        tool_def = {
-            "name": "test_tool",
-            "description": "A test tool that does something useful",
-            "timeout": 30000,
-        }
-        content = json.dumps(tool_def)
-        context = {"tool_name": "test_tool"}
-
-        findings = await analyzer.analyze(content, context)
-
-        finding = find_finding_by_rule(findings, "HEUR-001")
-        assert finding is None
-
-    @pytest.mark.asyncio
-    async def test_timeout_in_config_no_finding(self):
-        """Tool with timeout in config should not trigger HEUR-001."""
-        analyzer = ReadinessAnalyzer()
-        tool_def = {
-            "name": "test_tool",
-            "description": "A test tool that does something useful",
-            "config": {"timeoutMs": 30000},
-        }
-        content = json.dumps(tool_def)
-        context = {"tool_name": "test_tool"}
-
-        findings = await analyzer.analyze(content, context)
-
-        finding = find_finding_by_rule(findings, "HEUR-001")
-        assert finding is None
-
-
-class TestHEUR002TimeoutTooLong:
-    """Tests for HEUR-002: Timeout too long."""
-
-    @pytest.mark.asyncio
-    async def test_long_timeout_triggers_finding(self):
-        """Timeout > 5 minutes should trigger MEDIUM finding."""
-        analyzer = ReadinessAnalyzer()
-        tool_def = {
-            "name": "test_tool",
-            "description": "A test tool that does something useful",
-            "timeout": 600000,  # 10 minutes
-        }
-        content = json.dumps(tool_def)
-        context = {"tool_name": "test_tool"}
-
-        findings = await analyzer.analyze(content, context)
-
-        finding = find_finding_by_rule(findings, "HEUR-002")
-        assert finding is not None
-        assert finding.severity == "MEDIUM"
-        assert finding.details["value"] == 600000
-
-    @pytest.mark.asyncio
-    async def test_reasonable_timeout_no_finding(self):
-        """Timeout <= 5 minutes should not trigger HEUR-002."""
-        analyzer = ReadinessAnalyzer()
-        tool_def = {
-            "name": "test_tool",
-            "description": "A test tool that does something useful",
-            "timeout": 30000,  # 30 seconds
-        }
-        content = json.dumps(tool_def)
-        context = {"tool_name": "test_tool"}
-
-        findings = await analyzer.analyze(content, context)
-
-        finding = find_finding_by_rule(findings, "HEUR-002")
-        assert finding is None
 
 
 class TestHEUR003NoRetryLimit:
@@ -1091,8 +997,8 @@ class TestContextHandling:
         findings = await analyzer.analyze("{}", context)
 
         # Should use the tool definition from context
-        finding = find_finding_by_rule(findings, "HEUR-001")
-        assert finding is None  # Has timeout, so no HEUR-001
+        finding = find_finding_by_rule(findings, "HEUR-003")
+        assert finding is None  # Has maxRetries, so no HEUR-003
 
     @pytest.mark.asyncio
     async def test_plain_text_content(self):
@@ -1104,8 +1010,8 @@ class TestContextHandling:
         findings = await analyzer.analyze(content, context)
 
         # Should be parsed as a tool with only description
-        # Will trigger missing timeout, etc.
-        finding = find_finding_by_rule(findings, "HEUR-001")
+        # Will trigger no-retry-limit (HEUR-003) since maxRetries is missing
+        finding = find_finding_by_rule(findings, "HEUR-003")
         assert finding is not None
 
     @pytest.mark.asyncio
@@ -1162,20 +1068,6 @@ class TestFixtureFiles:
         # Bad tool should trigger HEUR-009 (short description)
         finding_009 = find_finding_by_rule(findings, "HEUR-009")
         assert finding_009 is not None
-
-    @pytest.mark.asyncio
-    async def test_long_timeout_fixture(self):
-        """Test tool_with_long_timeout.json triggers HEUR-002."""
-        analyzer = ReadinessAnalyzer()
-        tool_def = load_fixture("tool_with_long_timeout.json")
-        content = json.dumps(tool_def)
-        context = {"tool_name": tool_def["name"]}
-
-        findings = await analyzer.analyze(content, context)
-
-        finding = find_finding_by_rule(findings, "HEUR-002")
-        assert finding is not None
-        assert finding.severity == "MEDIUM"
 
     @pytest.mark.asyncio
     async def test_overloaded_scope_fixture(self):

--- a/tests/readiness/test_readiness_analyzer.py
+++ b/tests/readiness/test_readiness_analyzer.py
@@ -997,8 +997,9 @@ class TestContextHandling:
         findings = await analyzer.analyze("{}", context)
 
         # Should use the tool definition from context
-        finding = find_finding_by_rule(findings, "HEUR-003")
-        assert finding is None  # Has maxRetries, so no HEUR-003
+        # Tool has a good description, so HEUR-009 should not fire
+        finding = find_finding_by_rule(findings, "HEUR-009")
+        assert finding is None
 
     @pytest.mark.asyncio
     async def test_plain_text_content(self):

--- a/tests/readiness/test_readiness_integration.py
+++ b/tests/readiness/test_readiness_integration.py
@@ -257,13 +257,6 @@ class TestReadinessToolDefinitionParsing:
             [AnalyzerEnum.READINESS]
         )
 
-        # Should not have HEUR-001 (has timeout)
-        timeout_findings = [
-            f for f in result.findings
-            if f.details and f.details.get("rule_id") == "HEUR-001"
-        ]
-        assert len(timeout_findings) == 0
-
         # Should not have HEUR-003 (has maxRetries)
         retry_findings = [
             f for f in result.findings
@@ -362,24 +355,6 @@ class TestReadinessErrorHandling:
 
 class TestReadinessThreatCategories:
     """Test threat category assignments."""
-
-    @pytest.mark.asyncio
-    async def test_timeout_threat_category(self):
-        """HEUR-001 and HEUR-002 should use MISSING_TIMEOUT_GUARD."""
-        analyzer = ReadinessAnalyzer()
-        tool_def = {"name": "test", "description": "A test tool for something useful"}
-        content = json.dumps(tool_def)
-
-        findings = await analyzer.analyze(content, {"tool_name": "test"})
-
-        timeout_finding = None
-        for f in findings:
-            if f.details and f.details.get("rule_id") == "HEUR-001":
-                timeout_finding = f
-                break
-
-        assert timeout_finding is not None
-        assert timeout_finding.threat_category == "MISSING_TIMEOUT_GUARD"
 
     @pytest.mark.asyncio
     async def test_retry_threat_category(self):


### PR DESCRIPTION
## Summary

Removes HEUR-001 and HEUR-002 timeout checks from the readiness analyzer that were probing for non-standard fields on MCP Tool definitions.

## Problem

The readiness analyzer's `--analyzer readiness` mode was checking for `timeout`, `timeoutMs`, `timeout_ms`, and `timeoutSeconds` fields on tool definitions. However, the [MCP Tool specification](https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool) does not define any timeout field on the Tool type. These checks produced false positives for all tools.

## Changes

- Removed HEUR-001 (`_check_missing_timeout`) and HEUR-002 (`_check_timeout_too_long`) method definitions
- Removed calls to these methods in `_run_heuristic_checks`
- Updated docstring: 18 core heuristic rules remain (HEUR-003 through HEUR-020)
- Added comment explaining the removal with spec reference

## Verification

- Code passes lint checks
- The remaining 18 heuristic rules are unaffected

Fixes #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Readiness checks no longer report timeout-related findings, aligning results with the current MCP Tool specification.
  * Updated readiness output expectations so only supported heuristic checks are evaluated.
* **Tests**
  * Adjusted readiness test coverage to match the removed timeout checks.
  * Cleaned up integration and unit tests that referenced deprecated timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->