### PR TITLE
chore: bump version to 4.7.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-ai-mcp-scanner"
-version = "4.7.3"
+version = "4.7.4"
 description = "A tool to scan MCP servers and tools for security findings"
 authors = [
     {name = "Cisco"},

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ wheels = [
 
 [[package]]
 name = "cisco-ai-mcp-scanner"
-version = "4.7.3"
+version = "4.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "expandvars" },


### PR DESCRIPTION
Patch bump on top of 4.7.3 to ship the recently-merged LLM meta-analyzer (#149) and YARA false-positive fixes (#193) under a new release tag. No code changes — only ``pyproject.toml`` and the matching ``uv.lock`` entry are touched.