### PR TITLE
feat: first-class AWS Bedrock IAM/SSO auth for the LLM analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,14 @@ export MCP_SCANNER_ENDPOINT="https://us.api.inspect.aidefense.security.cisco.com
 
 **Tested LLMs:** OpenAI GPT-4o and GPT-4.1 | AWS Bedrock Claude 4.5 Sonnet
 
+> AWS Bedrock requires `boto3`: `pip install "cisco-ai-mcp-scanner[bedrock]"`.
+> With a `bedrock/*` model and valid AWS credentials (IAM role / SSO / profile),
+> the LLM analyzer activates automatically — **no `MCP_SCANNER_LLM_API_KEY` is
+> required** (and you should not set a placeholder one).
+
 ```bash
-# AWS Bedrock Claude with AWS credentials (profile)
-export AWS_PROFILE="your-profile"
+# AWS Bedrock Claude with AWS credentials (IAM role / SSO / profile)
+export AWS_PROFILE="your-profile"   # or rely on an IAM role / SSO session
 export AWS_REGION="us-east-1"
 export MCP_SCANNER_LLM_MODEL="bedrock/anthropic.claude-sonnet-4-5-20250929-v2:0" # Any AWS Bedrock supported model
 

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -138,21 +138,40 @@ export MCP_SCANNER_LLM_MODEL="gemini/gemini-pro"
 
 ### AWS Bedrock
 
+Bedrock support requires `boto3`, which is shipped as an optional extra:
+
+```bash
+pip install "cisco-ai-mcp-scanner[bedrock]"
+```
+
+`bedrock/*` models can authenticate three ways, in priority order:
+
+1. **AWS credential chain (IAM role / SSO / profile / session token)** — the
+   recommended option. **No `MCP_SCANNER_LLM_API_KEY` is required**; the
+   analyzer activates automatically for `bedrock/*` models and litellm signs
+   requests with your standard AWS credentials. Do **not** set a placeholder
+   API key — it would be sent to Bedrock and rejected.
+2. **Bedrock bearer token** via `AWS_BEARER_TOKEN_BEDROCK`.
+3. **Bedrock API key** via `MCP_SCANNER_LLM_API_KEY`.
+
+**Environment setup (IAM / SSO — no API key):**
+```bash
+# Valid AWS credentials available via the standard chain (IAM role / SSO /
+# `aws configure` profile). No MCP_SCANNER_LLM_API_KEY needed.
+export AWS_REGION="eu-central-1"
+export MCP_SCANNER_LLM_MODEL="bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+mcp-scanner --analyzers llm static --tools tools.json
+```
+
 ```python
+# IAM / credential-chain auth — no api key
 config = Config(
-    llm_provider_api_key="your-aws-access-key-id",
     llm_model="bedrock/anthropic.claude-v2",
+    aws_region_name="us-east-1",
     llm_temperature=0.1,
     llm_max_tokens=1000,
 )
-```
-
-**Environment setup:**
-```bash
-export AWS_ACCESS_KEY_ID="your-aws-access-key-id"
-export AWS_SECRET_ACCESS_KEY="your-aws-secret-access-key"
-export AWS_REGION="us-east-1"
-export MCP_SCANNER_LLM_MODEL="bedrock/anthropic.claude-v2"
 ```
 
 ### Ollama (Local Models)

--- a/mcpscanner/cli.py
+++ b/mcpscanner/cli.py
@@ -1551,11 +1551,20 @@ async def main():
             if AnalyzerEnum.YARA in selected_analyzers:
                 analyzers.append(YaraAnalyzer(rules_dir=args.rules_path))
             if AnalyzerEnum.LLM in selected_analyzers:
-                if cfg.llm_provider_api_key:
+                # Mirror Scanner.__init__'s ``(api_key or is_bedrock)`` gate so
+                # that ``bedrock/*`` models authenticating via the AWS
+                # credential chain (IAM/SSO) activate the analyzer without
+                # requiring a (placeholder) MCP_SCANNER_LLM_API_KEY.
+                _llm_is_bedrock = bool(
+                    cfg.llm_model and "bedrock/" in cfg.llm_model
+                )
+                if cfg.llm_provider_api_key or _llm_is_bedrock:
                     analyzers.append(LLMAnalyzer(cfg))
                 else:
                     print(
-                        "Warning: LLM analyzer requested but MCP_SCANNER_LLM_API_KEY not set",
+                        "Warning: LLM analyzer requested but MCP_SCANNER_LLM_API_KEY "
+                        "not set (for bedrock/* models, configure AWS credentials "
+                        "instead of an API key)",
                         file=sys.stderr,
                     )
             if AnalyzerEnum.API in selected_analyzers:

--- a/mcpscanner/core/analyzers/behavioral/alignment/alignment_llm_client.py
+++ b/mcpscanner/core/analyzers/behavioral/alignment/alignment_llm_client.py
@@ -35,6 +35,7 @@ from litellm import acompletion
 
 from .....config.config import Config
 from .....config.constants import MCPScannerConstants
+from .....utils.bedrock import ensure_bedrock_dependencies
 from .....utils.log_format import ERROR_TRUNCATE, RESPONSE_DEBUG_MAX, truncate
 
 
@@ -111,6 +112,12 @@ class AlignmentLLMClient:
         self._api_version = config.llm_api_version
 
         is_bedrock = bool(self._model and "bedrock/" in self._model)
+
+        # Fail fast with an actionable message if boto3 is missing, instead of
+        # litellm's opaque "No module named 'boto3'" at request time.
+        if is_bedrock:
+            ensure_bedrock_dependencies(self._model)
+
         api_key = getattr(config, "llm_provider_api_key", None)
         bearer_token = getattr(config, "aws_bearer_token_bedrock", None)
 

--- a/mcpscanner/core/analyzers/llm_analyzer.py
+++ b/mcpscanner/core/analyzers/llm_analyzer.py
@@ -29,6 +29,7 @@ from litellm import acompletion
 from ...config.config import Config
 from ...config.constants import MCPScannerConstants
 from ...threats.threats import LLM_THREAT_MAPPING
+from ...utils.bedrock import ensure_bedrock_dependencies
 from .base import BaseAnalyzer, SecurityFinding
 
 
@@ -71,6 +72,11 @@ class LLMAnalyzer(BaseAnalyzer):
 
         # Detect Bedrock model
         is_bedrock = self._model and "bedrock/" in self._model
+
+        # Fail fast with an actionable message if boto3 is missing, instead of
+        # litellm's opaque "No module named 'boto3'" at request time.
+        if is_bedrock:
+            ensure_bedrock_dependencies(self._model)
 
         # Authentication strategy based on provider:
         # 1. Non-Bedrock providers (OpenAI, Anthropic, etc.): API key required

--- a/mcpscanner/core/analyzers/meta_analyzer.py
+++ b/mcpscanner/core/analyzers/meta_analyzer.py
@@ -49,6 +49,7 @@ from litellm import acompletion
 
 from ...config.config import Config
 from ...config.constants import MCPScannerConstants
+from ...utils.bedrock import ensure_bedrock_dependencies
 from ...utils.logging_config import get_logger
 from .base import SecurityFinding
 
@@ -185,6 +186,11 @@ class MetaAnalyzer:
 
         self._model = config.llm_model
         is_bedrock = self._model and "bedrock/" in self._model
+
+        # Fail fast with an actionable message if boto3 is missing, instead of
+        # litellm's opaque "No module named 'boto3'" at request time.
+        if is_bedrock:
+            ensure_bedrock_dependencies(self._model)
 
         if not is_bedrock:
             if not config.llm_provider_api_key:

--- a/mcpscanner/utils/__init__.py
+++ b/mcpscanner/utils/__init__.py
@@ -16,7 +16,20 @@
 
 """Utilities module for MCP Scanner."""
 
+from .bedrock import (
+    BedrockDependencyError,
+    ensure_bedrock_dependencies,
+    is_bedrock_model,
+)
 from .di_container import DIContainer
 from .logging_config import setup_logger, set_log_level, set_verbose_logging
 
-__all__ = ["DIContainer", "setup_logger", "set_log_level", "set_verbose_logging"]
+__all__ = [
+    "DIContainer",
+    "setup_logger",
+    "set_log_level",
+    "set_verbose_logging",
+    "BedrockDependencyError",
+    "ensure_bedrock_dependencies",
+    "is_bedrock_model",
+]

--- a/mcpscanner/utils/bedrock.py
+++ b/mcpscanner/utils/bedrock.py
@@ -1,0 +1,61 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for AWS Bedrock LLM support.
+
+Bedrock is reached through litellm, which signs requests with AWS SigV4 using
+``boto3``. ``boto3`` is an optional dependency (installed via the ``bedrock``
+extra) so non-Bedrock users are not forced to pull in the AWS SDK. These
+helpers centralise the "is this a Bedrock model?" check and a fail-fast
+pre-flight that surfaces a clear, actionable error when ``boto3`` is missing
+instead of litellm's opaque ``No module named 'boto3'`` at request time.
+"""
+
+import importlib.util
+
+
+class BedrockDependencyError(ImportError):
+    """Raised when a Bedrock model is configured but ``boto3`` is not installed."""
+
+
+def is_bedrock_model(model: str | None) -> bool:
+    """Return ``True`` when ``model`` is a litellm ``bedrock/*`` model id."""
+    return bool(model and "bedrock/" in model)
+
+
+def ensure_bedrock_dependencies(model: str | None) -> None:
+    """Validate that Bedrock runtime dependencies are importable.
+
+    litellm requires ``boto3`` to authenticate ``bedrock/*`` models regardless
+    of whether credentials come from a Bedrock API key, an
+    ``AWS_BEARER_TOKEN_BEDROCK`` bearer token, or the standard AWS credential
+    chain (IAM role / SSO / profile / session token).
+
+    Args:
+        model: The configured litellm model id.
+
+    Raises:
+        BedrockDependencyError: If ``model`` is a Bedrock model but ``boto3``
+            cannot be imported.
+    """
+    if not is_bedrock_model(model):
+        return
+    if importlib.util.find_spec("boto3") is None:
+        raise BedrockDependencyError(
+            "boto3 is required to use AWS Bedrock models "
+            f"('{model}') but is not installed. Install it with "
+            "'pip install \"cisco-ai-mcp-scanner[bedrock]\"' (or 'pip install boto3')."
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# AWS Bedrock support. litellm signs bedrock/* requests with AWS SigV4 via
+# boto3, which is needed for every Bedrock auth method (API key, bearer token,
+# or the AWS credential chain / IAM / SSO). Kept optional so non-Bedrock users
+# do not pull in the AWS SDK.
+bedrock = [
+    "boto3>=1.34.0",
+]
 js = [
     "tree-sitter>=0.21.0",
     "tree-sitter-javascript>=0.21.0",
@@ -102,6 +109,9 @@ dev = [
     "isort>=5.13.0",
     "mypy>=1.8.0",
     "pre-commit>=3.6.0",
+    # Required so the Bedrock auth tests (and the boto3 pre-flight) can run;
+    # boto3 itself is an optional runtime extra (see [project.optional-dependencies]).
+    "boto3>=1.34.0",
 ]
 
 [project.urls]

--- a/tests/test_bedrock_auth.py
+++ b/tests/test_bedrock_auth.py
@@ -1,0 +1,178 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for first-class AWS Bedrock (IAM/SSO) activation of the LLM analyzer.
+
+These cover the two halves of the Bedrock-without-an-API-key fix:
+
+1. The boto3 pre-flight (``ensure_bedrock_dependencies``) that turns litellm's
+   opaque ``No module named 'boto3'`` into an actionable error.
+2. The CLI ``static`` gate that activates the LLM analyzer for ``bedrock/*``
+   models authenticating via the AWS credential chain, without requiring a
+   (placeholder) ``MCP_SCANNER_LLM_API_KEY``.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcpscanner.config import Config
+from mcpscanner.core.analyzers.llm_analyzer import LLMAnalyzer
+from mcpscanner.utils import bedrock as bedrock_utils
+from mcpscanner.utils.bedrock import (
+    BedrockDependencyError,
+    ensure_bedrock_dependencies,
+    is_bedrock_model,
+)
+
+_BEDROCK_MODEL = "bedrock/eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+
+class TestIsBedrockModel:
+    def test_recognises_bedrock_models(self):
+        assert is_bedrock_model(_BEDROCK_MODEL) is True
+        assert is_bedrock_model("bedrock/anthropic.claude-3-sonnet") is True
+
+    def test_rejects_non_bedrock_and_empty(self):
+        assert is_bedrock_model("gpt-4o") is False
+        assert is_bedrock_model("openai/gpt-4o") is False
+        assert is_bedrock_model("") is False
+        assert is_bedrock_model(None) is False
+
+
+class TestEnsureBedrockDependencies:
+    def test_noop_for_non_bedrock_even_without_boto3(self):
+        # Non-Bedrock models must never require boto3, regardless of whether it
+        # is importable.
+        with patch.object(bedrock_utils.importlib.util, "find_spec", return_value=None):
+            ensure_bedrock_dependencies("openai/gpt-4o")  # must not raise
+
+    def test_raises_actionable_error_when_boto3_missing(self):
+        with patch.object(bedrock_utils.importlib.util, "find_spec", return_value=None):
+            with pytest.raises(BedrockDependencyError) as exc:
+                ensure_bedrock_dependencies(_BEDROCK_MODEL)
+        msg = str(exc.value)
+        assert "boto3" in msg
+        assert "bedrock" in msg.lower()
+
+    def test_passes_when_boto3_present(self):
+        with patch.object(
+            bedrock_utils.importlib.util, "find_spec", return_value=object()
+        ):
+            ensure_bedrock_dependencies(_BEDROCK_MODEL)  # must not raise
+
+
+class TestLLMAnalyzerBedrockPreflight:
+    def test_llm_analyzer_surfaces_missing_boto3(self):
+        config = Config(llm_model=_BEDROCK_MODEL, aws_region_name="eu-central-1")
+        with patch.object(bedrock_utils.importlib.util, "find_spec", return_value=None):
+            with pytest.raises(BedrockDependencyError):
+                LLMAnalyzer(config)
+
+    def test_llm_analyzer_activates_without_api_key_for_bedrock(self):
+        # No API key + Bedrock model + AWS creds = analyzer should construct and
+        # not pass an api_key down to litellm.
+        config = Config(llm_model=_BEDROCK_MODEL, aws_region_name="eu-central-1")
+        analyzer = LLMAnalyzer(config)
+        assert analyzer._api_key is None
+        assert analyzer._aws_region == "eu-central-1"
+
+
+class TestCLIStaticBedrockGate:
+    """The ``static`` subcommand must activate the LLM analyzer for Bedrock+IAM."""
+
+    @pytest.fixture
+    def tools_json_file(self, tmp_path):
+        data = {
+            "tools": [
+                {
+                    "name": "safe_calculator",
+                    "description": "Adds two numbers",
+                    "inputSchema": {"type": "object"},
+                }
+            ]
+        }
+        file_path = tmp_path / "tools.json"
+        file_path.write_text(json.dumps(data))
+        return str(file_path)
+
+    @pytest.mark.asyncio
+    async def test_bedrock_model_activates_llm_without_api_key(
+        self, tools_json_file, capsys, monkeypatch
+    ):
+        from mcpscanner.cli import main
+
+        monkeypatch.setenv("MCP_SCANNER_LLM_MODEL", _BEDROCK_MODEL)
+        monkeypatch.setenv("AWS_REGION", "eu-central-1")
+        monkeypatch.delenv("MCP_SCANNER_LLM_API_KEY", raising=False)
+
+        fake_llm = MagicMock(name="LLMAnalyzerInstance")
+        llm_cls = MagicMock(return_value=fake_llm)
+
+        fake_static = MagicMock()
+        fake_static.scan_tools_file = AsyncMock(return_value=[])
+
+        test_args = [
+            "mcp-scanner",
+            "--analyzers",
+            "llm",
+            "static",
+            "--tools",
+            tools_json_file,
+        ]
+
+        with (
+            patch("sys.argv", test_args),
+            patch("mcpscanner.cli.LLMAnalyzer", llm_cls),
+            patch("mcpscanner.cli.StaticAnalyzer", return_value=fake_static),
+        ):
+            await main()
+
+        # The LLM analyzer must have been constructed despite no API key...
+        llm_cls.assert_called_once()
+        # ...and the skip warning must NOT be emitted.
+        captured = capsys.readouterr()
+        assert "LLM analyzer requested but MCP_SCANNER_LLM_API_KEY" not in captured.err
+
+    @pytest.mark.asyncio
+    async def test_non_bedrock_without_api_key_still_warns_and_skips(
+        self, tools_json_file, capsys, monkeypatch
+    ):
+        from mcpscanner.cli import main
+
+        monkeypatch.setenv("MCP_SCANNER_LLM_MODEL", "openai/gpt-4o")
+        monkeypatch.delenv("MCP_SCANNER_LLM_API_KEY", raising=False)
+
+        llm_cls = MagicMock()
+
+        test_args = [
+            "mcp-scanner",
+            "--analyzers",
+            "llm",
+            "static",
+            "--tools",
+            tools_json_file,
+        ]
+
+        with patch("sys.argv", test_args), patch("mcpscanner.cli.LLMAnalyzer", llm_cls):
+            with pytest.raises(SystemExit):
+                # No analyzers available -> CLI exits(1).
+                await main()
+
+        llm_cls.assert_not_called()
+        captured = capsys.readouterr()
+        assert "LLM analyzer requested but MCP_SCANNER_LLM_API_KEY" in captured.err


### PR DESCRIPTION
Activate and run the LLM analyzer for bedrock/* models using the AWS credential chain (IAM role / SSO / profile / session token) without requiring a (placeholder) MCP_SCANNER_LLM_API_KEY.

- cli: the `static` subcommand LLM gate now mirrors Scanner.__init__'s `(api_key OR is_bedrock)` rule, so Bedrock models activate via AWS credentials instead of being skipped.
- utils/bedrock: shared is_bedrock_model() + ensure_bedrock_dependencies() pre-flight that fails fast with an actionable message when boto3 is missing, instead of litellm's opaque "No module named 'boto3'".
- Wire the boto3 pre-flight into LLMAnalyzer, MetaAnalyzer, and AlignmentLLMClient.
- pyproject: add `bedrock` optional extra (boto3), add boto3 to the dev group so Bedrock tests run in CI, bump version 4.7.4 -> 4.7.5.
- docs/README: document the [bedrock] extra and IAM-without-key activation.
- tests: cover the helper, analyzer pre-flight, and CLI gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pypi-scan` and `npm-scan` commands for package scanning in a Docker sandbox, with optional local execution.
  * Bedrock models now activate using AWS credentials without requiring an LLM API key.

* **Bug Fixes**
  * Improved error reporting for package scans and analyzer failures.
  * Added clearer, earlier feedback when Bedrock prerequisites are missing.

* **Documentation**
  * Updated Bedrock installation, authentication, and configuration guidance.

* **Tests**
  * Added coverage for Bedrock authentication, dependency checks, and CLI activation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->