### PR TITLE
fix: preserve all individual findings per analyzer in report output

### DIFF
--- a/mcpscanner/core/report_generator.py
+++ b/mcpscanner/core/report_generator.py
@@ -57,6 +57,7 @@ async def results_to_json(scan_results) -> List[Dict[str, Any]]:
                     "threat_names": [],
                     "threat_summary": "No threats detected",
                     "total_findings": 0,
+                    "detailed_findings": [],
                 }
                 summaries_by_analyzer[analyzer_key] = []
 
@@ -69,6 +70,7 @@ async def results_to_json(scan_results) -> List[Dict[str, Any]]:
                     "threat_names": [],
                     "threat_summary": "N/A",
                     "total_findings": 0,
+                    "detailed_findings": [],
                 }
                 summaries_by_analyzer[analyzer] = []
 
@@ -84,6 +86,24 @@ async def results_to_json(scan_results) -> List[Dict[str, Any]]:
                 if getattr(finding, "details", None)
                 else "unknown"
             )
+
+            # Preserve every individual finding. The aggregated fields above
+            # (severity/threat_summary/total_findings) keep only a rolled-up
+            # view, which collapses analyzers that emit many distinct findings
+            # per item (e.g. the readiness analyzer's HEUR-* rules). Without
+            # this list all but the first finding's details are lost in both
+            # --raw and --format detailed output.
+            findings_by_analyzer[analyzer].setdefault("detailed_findings", []).append(
+                {
+                    "severity": finding.severity,
+                    "summary": getattr(finding, "summary", None),
+                    "threat_category": getattr(finding, "threat_category", None),
+                    "threat_type": threat_type,
+                    "details": dict(getattr(finding, "details", None) or {}),
+                    "mcp_taxonomy": getattr(finding, "mcp_taxonomy", None),
+                }
+            )
+
             if threat_type not in findings_by_analyzer[analyzer]["threat_names"]:
                 findings_by_analyzer[analyzer]["threat_names"].append(threat_type)
             if finding.severity == "HIGH":
@@ -495,6 +515,39 @@ class ReportGenerator:
                         f"    - Threat Names: {', '.join(threat_names) if threat_names else 'None'}"
                     )
                     output.append(f"    - Total Findings: {total_findings}")
+
+                    # Surface each individual finding. The aggregated fields
+                    # above keep only the first summary, which hides the bulk
+                    # of findings from analyzers that emit many per item
+                    # (e.g. the readiness analyzer's HEUR-* rules).
+                    detailed_findings = data.get("detailed_findings", [])
+                    if len(detailed_findings) > 1:
+                        output.append(
+                            f"    - Individual Findings ({len(detailed_findings)}):"
+                        )
+                        for idx, df in enumerate(detailed_findings, 1):
+                            df_details = df.get("details") or {}
+                            rule_id = df_details.get("rule_id")
+                            label = (
+                                df.get("threat_category")
+                                or df.get("threat_type")
+                                or "finding"
+                            )
+                            header = f"      [{idx}] {df.get('severity', 'UNKNOWN')}"
+                            if rule_id:
+                                header += f" {rule_id}"
+                            header += f" — {label}"
+                            output.append(header)
+                            if df.get("summary"):
+                                output.append(f"          • Summary: {df['summary']}")
+                            recommendation = df_details.get("recommendation")
+                            if recommendation:
+                                output.append(
+                                    f"          • Recommendation: {recommendation}"
+                                )
+                            location = df_details.get("location")
+                            if location:
+                                output.append(f"          • Location: {location}")
 
                     # Add MCP Taxonomy details if available
                     mcp_taxonomies = data.get("mcp_taxonomies", [])

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -543,6 +543,97 @@ class TestResultsToJson:
         assert json_results[0]["status"] == "failed"
 
     @pytest.mark.asyncio
+    async def test_results_to_json_preserves_all_findings_per_analyzer(self):
+        """Multiple findings from one analyzer must all be preserved.
+
+        Regression for the readiness analyzer (and any analyzer emitting many
+        findings per tool): the aggregated fields only keep the first summary,
+        so ``detailed_findings`` must carry every individual finding.
+        """
+        findings = [
+            SecurityFinding(
+                SeverityLevel.HIGH,
+                "Tool does not specify a timeout",
+                "READINESS",
+                "MISSING_TIMEOUT_GUARD",
+                {"rule_id": "HEUR-001", "recommendation": "Add a timeout field"},
+            ),
+            SecurityFinding(
+                SeverityLevel.MEDIUM,
+                "Unsafe retry loop detected",
+                "READINESS",
+                "UNSAFE_RETRY_LOOP",
+                {"rule_id": "HEUR-003", "recommendation": "Cap the retries"},
+            ),
+            SecurityFinding(
+                SeverityLevel.LOW,
+                "Missing error schema",
+                "READINESS",
+                "MISSING_ERROR_SCHEMA",
+                {"rule_id": "HEUR-006"},
+            ),
+        ]
+        result = ToolScanResult(
+            "appscan_get_apps", "desc", "completed", ["READINESS"], findings
+        )
+
+        json_results = await results_to_json([result])
+
+        data = json_results[0]["findings"]["readiness_analyzer"]
+        assert data["total_findings"] == 3
+        detailed = data["detailed_findings"]
+        assert len(detailed) == 3
+
+        rule_ids = {df["details"].get("rule_id") for df in detailed}
+        assert rule_ids == {"HEUR-001", "HEUR-003", "HEUR-006"}
+
+        summaries = {df["summary"] for df in detailed}
+        assert "Unsafe retry loop detected" in summaries
+        assert "Missing error schema" in summaries
+
+        # Aggregated severity must reflect the highest individual finding.
+        assert data["severity"] == "HIGH"
+
+    @pytest.mark.asyncio
+    async def test_detailed_format_renders_all_individual_findings(self):
+        """--format detailed must surface every finding, not just the first."""
+        findings = [
+            SecurityFinding(
+                SeverityLevel.HIGH,
+                "Tool does not specify a timeout",
+                "READINESS",
+                "MISSING_TIMEOUT_GUARD",
+                {"rule_id": "HEUR-001", "recommendation": "Add a timeout field"},
+            ),
+            SecurityFinding(
+                SeverityLevel.MEDIUM,
+                "Unsafe retry loop detected",
+                "READINESS",
+                "UNSAFE_RETRY_LOOP",
+                {"rule_id": "HEUR-003"},
+            ),
+        ]
+        result = ToolScanResult(
+            "appscan_get_apps", "desc", "completed", ["READINESS"], findings
+        )
+
+        json_results = await results_to_json([result])
+        scan_data = {
+            "server_url": "http://test-server.com",
+            "scan_results": json_results,
+            "requested_analyzers": ["readiness"],
+        }
+        output = ReportGenerator(scan_data).format_output(OutputFormat.DETAILED)
+
+        assert "Individual Findings (2):" in output
+        # Both rule ids and the second finding's summary (previously hidden)
+        # must now be visible.
+        assert "HEUR-001" in output
+        assert "HEUR-003" in output
+        assert "Unsafe retry loop detected" in output
+        assert "Add a timeout field" in output
+
+    @pytest.mark.asyncio
     async def test_results_to_json_finding_serialization(self):
         """Test that findings are properly serialized."""
         finding = SecurityFinding(


### PR DESCRIPTION
Aggregating findings per analyzer in results_to_json kept only the first finding's summary, so analyzers that emit many findings per item (notably the readiness analyzer's HEUR-* rules) lost all but one finding in both --raw and --format detailed output.

- results_to_json: add a detailed_findings list per analyzer that preserves each finding's severity, summary, threat_category/type, full details (rule_id, recommendation, location) and mcp_taxonomy. Existing aggregated fields are unchanged for backward compatibility; --raw now includes every finding automatically.
- _format_detailed: render an "Individual Findings (N)" section listing each finding when an analyzer reports more than one.
- tests: cover JSON preservation and detailed rendering of all findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Detailed reports now include individual findings for each analyzer, making it easier to review every issue separately.
  * JSON output now preserves per-finding details alongside the existing summary data.

* **Bug Fixes**
  * Fixed an issue where multiple findings from the same analyzer could be collapsed into a single view.
  * Improved severity reporting so analyzer-level severity reflects the highest individual finding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->