### PR TITLE
fix: use MCP-registered tool names across languages

### DIFF
--- a/mcpscanner/core/static_analysis/native_analyzer.py
+++ b/mcpscanner/core/static_analysis/native_analyzer.py
@@ -268,6 +268,33 @@ def _strip_string_quotes(s: str) -> str:
     return s
 
 
+def _bare_handler_symbol(name: str) -> str:
+    """Return the unqualified handler symbol (``Type.method`` -> ``method``)."""
+    if "." in name:
+        return name.rsplit(".", 1)[-1]
+    return name
+
+
+def _effective_capability_name(
+    registered_name: Optional[str],
+    handler_name: str,
+    capability: str,
+) -> str:
+    """Resolve the MCP-registered capability name for reports and LLM prompts.
+
+    Prefer an explicitly registered name (from ``AddTool``, ``#[tool(name=…)]``,
+    etc.). For tools without one, default to the bare handler symbol so
+    ``ShellExecutorService.execute_shell_command`` and ``executeShellCommand``
+    both surface as ``execute_shell_command`` / ``executeShellCommand`` rather
+    than class-qualified Java/Rust-style names.
+    """
+    if registered_name:
+        return registered_name
+    if capability == "tool":
+        return _bare_handler_symbol(handler_name)
+    return handler_name
+
+
 def _normalize_capability(method_name: str) -> str:
     """Map a raw SDK method name onto the canonical capability kind.
 
@@ -1393,6 +1420,7 @@ class NativeAnalyzer:
         have empty bodies.
         """
         name = registered_name or handler_name_hint or "<unresolved>"
+        name = _effective_capability_name(registered_name, name, capability)
         ctx = FunctionContext(
             name=name,
             decorator_types=[f"<{source_kind}>.{capability}"],
@@ -2156,15 +2184,9 @@ class NativeAnalyzer:
         if ctx is None:
             return
 
-        # When an inline (anonymous) handler is registered as
-        # ``server.tool('add', ...)``, prefer the registered MCP name in
-        # CLI/SDK output. For named functions we keep the symbol name
-        # because that's also useful context; combine when both exist.
-        if registered_name:
-            if not ctx.name or ctx.name == "<anonymous>":
-                ctx.name = registered_name
-            elif registered_name != ctx.name and registered_name not in ctx.name:
-                ctx.name = f"{registered_name} ({ctx.name})"
+        ctx.name = _effective_capability_name(
+            registered_name, ctx.name, capability
+        )
 
         cap_tag = f"<{source_kind}>.{capability}"
         if cap_tag not in ctx.decorator_types:
@@ -3017,50 +3039,107 @@ class NativeAnalyzer:
             "handler_name": handler_name,
         }
 
-    def _ts_extract_handler_from_object(
-        self, obj_node: "Node", func_types: Set[str]
-    ) -> "tuple[Optional[str], Optional[Node]]":
-        """Pull ``name`` + handler out of an object literal argument."""
-        obj_name: Optional[str] = None
-        obj_handler: Optional["Node"] = None
+    def _ts_field_key_text(self, key_node: "Node") -> str:
+        """Normalize an object-field key across JS/TS/Go/C# grammars."""
+        if key_node.type == "literal_element":
+            for sub in key_node.children:
+                if sub.type in ("field_identifier", "identifier", "property_identifier"):
+                    return self._ts_get_node_text(sub).strip()
+        text = self._ts_get_node_text(key_node).strip()
+        return _strip_string_quotes(text)
 
-        # ``pair`` (JS), ``field_initialization`` (TS), ``key_value`` (Go),
-        # ``element`` (Ruby) — try them all.
+    def _ts_string_value_from_object_field(self, value_node: "Node") -> Optional[str]:
+        """Extract a string value from an object-field value node."""
+        string_node_types = {
+            "string",
+            "string_literal",
+            "template_string",
+            "raw_string_literal",
+            "interpreted_string_literal",
+        }
+        if value_node.type in string_node_types:
+            return _strip_string_quotes(self._ts_get_node_text(value_node))
+        if value_node.type == "literal_element":
+            for sub in value_node.children:
+                lit = self._ts_extract_string_literal_text(sub)
+                if lit is not None:
+                    return lit
+        lit = self._ts_extract_string_literal_text(value_node)
+        return lit
+
+    def _ts_object_entry_key_value(
+        self, entry_node: "Node"
+    ) -> "tuple[Optional[str], Optional[Node]]":
+        """Return ``(field_key, value_node)`` for one object/composite entry."""
         pair_types = {
             "pair",
             "field_initialization",
             "key_value",
             "object_property",
             "element",
+            "keyed_element",
+        }
+        if entry_node.type not in pair_types:
+            return None, None
+
+        key_node = entry_node.child_by_field_name("key")
+        value_node = entry_node.child_by_field_name("value")
+        if key_node is not None and value_node is not None:
+            return self._ts_field_key_text(key_node), value_node
+
+        if entry_node.type == "keyed_element":
+            elements = [
+                c for c in entry_node.children if c.type == "literal_element"
+            ]
+            if len(elements) >= 2:
+                return self._ts_field_key_text(elements[0]), elements[1]
+        return None, None
+
+    def _ts_extract_handler_from_object(
+        self, obj_node: "Node", func_types: Set[str]
+    ) -> "tuple[Optional[str], Optional[Node]]":
+        """Pull ``name`` + handler out of an object/composite literal argument."""
+        obj_name: Optional[str] = None
+        obj_handler: Optional["Node"] = None
+        handler_keys = {"handler", "execute", "fn", "callback", "run"}
+        entry_types = {
+            "pair",
+            "field_initialization",
+            "key_value",
+            "object_property",
+            "element",
+            "keyed_element",
+        }
+        container_types = {
+            "object",
+            "object_expression",
+            "literal_value",
+            "composite_literal",
         }
 
-        for child in obj_node.children:
-            if child.type not in pair_types:
-                continue
-            key_node = child.child_by_field_name("key")
-            value_node = child.child_by_field_name("value")
-            if key_node is None or value_node is None:
-                continue
-            key = _strip_string_quotes(self._ts_get_node_text(key_node).strip())
-            if (
-                key == "name"
-                and obj_name is None
-                and value_node.type
-                in (
-                    "string",
-                    "string_literal",
-                    "template_string",
-                    "raw_string_literal",
-                    "interpreted_string_literal",
-                )
-            ):
-                obj_name = _strip_string_quotes(self._ts_get_node_text(value_node))
-            elif (
-                key in ("handler", "execute", "fn", "callback", "run")
-                and value_node.type in func_types
-            ):
-                obj_handler = value_node
+        def visit(node: "Node") -> None:
+            nonlocal obj_name, obj_handler
+            if node.type in entry_types:
+                key, value_node = self._ts_object_entry_key_value(node)
+                if key and value_node is not None:
+                    key_norm = key.lower()
+                    if key_norm == "name" and obj_name is None:
+                        lit = self._ts_string_value_from_object_field(value_node)
+                        if lit is not None:
+                            obj_name = lit
+                    elif (
+                        key_norm in handler_keys
+                        and obj_handler is None
+                        and value_node.type in func_types
+                    ):
+                        obj_handler = value_node
+            if node is not obj_node and node.type in func_types and obj_handler is None:
+                obj_handler = node
+            for child in node.children:
+                if child.type in container_types or child.type in entry_types:
+                    visit(child)
 
+        visit(obj_node)
         return obj_name, obj_handler
 
     def _ts_find_function_def_by_name(

--- a/mcpscanner/core/static_analysis/native_analyzer.py
+++ b/mcpscanner/core/static_analysis/native_analyzer.py
@@ -2992,11 +2992,12 @@ class NativeAnalyzer:
             "interpreted_string_literal",
         }
         name: Optional[str] = None
-        inline_handler: Optional["Node"] = None
         # Positional slots preserve argument order so the first ref
         # (``tool.alias``) is not confused with later identifiers
         # (``toolDescription``, ``paramSchema``) in Graph-style loops.
         positional: List[tuple[str, Any]] = []
+        direct_inline_handlers: List["Node"] = []
+        object_inline_handlers: List["Node"] = []
 
         for child in args_node.children:
             if child.type in ("(", ")", ",", "comment"):
@@ -3004,6 +3005,7 @@ class NativeAnalyzer:
 
             if child.type in func_types:
                 positional.append(("inline", child))
+                direct_inline_handlers.append(child)
                 continue
 
             if child.type == "identifier":
@@ -3033,6 +3035,7 @@ class NativeAnalyzer:
                     positional.append(("string", obj_name))
                 if obj_handler is not None:
                     positional.append(("inline", obj_handler))
+                    object_inline_handlers.append(obj_handler)
                 if not obj_name and obj_handler is None:
                     positional.append(("schema", None))
                 continue
@@ -3047,6 +3050,7 @@ class NativeAnalyzer:
                             positional.append(("string", obj_name))
                         if obj_handler is not None:
                             positional.append(("inline", obj_handler))
+                            object_inline_handlers.append(obj_handler)
                         if not obj_name and obj_handler is None:
                             positional.append(("schema", None))
                         break
@@ -3056,10 +3060,13 @@ class NativeAnalyzer:
                 name = val
                 break
 
-        inline_handlers = [val for kind, val in positional if kind == "inline"]
+        if direct_inline_handlers:
+            handler_node = direct_inline_handlers[-1]
+        elif object_inline_handlers:
+            handler_node = object_inline_handlers[-1]
+        else:
+            handler_node = None
         refs = [val for kind, val in positional if kind == "ref"]
-
-        handler_node = inline_handlers[-1] if inline_handlers else None
         handler_name: Optional[str] = None
 
         if handler_node is None and refs:
@@ -3463,6 +3470,34 @@ class NativeAnalyzer:
         lit = self._ts_extract_string_literal_text(value_node)
         return lit
 
+    def _ts_direct_function_value(
+        self, value_node: "Node", func_types: Set[str]
+    ) -> Optional["Node"]:
+        """Return an inline function at a field value root without nested-object descent.
+
+        Registration schema/config objects may nest decoy ``handler`` callbacks
+        several levels deep. Only unwrap grammar wrappers (parentheses, unary,
+        ``literal_element``) — never descend into object/composite literals.
+        """
+        if value_node.type in func_types:
+            return value_node
+        if value_node.type == "literal_element":
+            for sub in value_node.children:
+                if sub.type in func_types:
+                    return sub
+        unwrap_types = {
+            "parenthesized_expression",
+            "unary_expression",
+            "as_expression",
+            "await_expression",
+        }
+        if value_node.type in unwrap_types:
+            for sub in value_node.children:
+                found = self._ts_direct_function_value(sub, func_types)
+                if found is not None:
+                    return found
+        return None
+
     def _ts_object_entry_key_value(
         self, entry_node: "Node"
     ) -> "tuple[Optional[str], Optional[Node]]":
@@ -3491,13 +3526,10 @@ class NativeAnalyzer:
                 return self._ts_field_key_text(elements[0]), elements[1]
         return None, None
 
-    def _ts_extract_handler_from_object(
-        self, obj_node: "Node", func_types: Set[str]
-    ) -> "tuple[Optional[str], Optional[Node]]":
-        """Pull ``name`` + handler out of an object/composite literal argument."""
-        obj_name: Optional[str] = None
-        obj_handler: Optional["Node"] = None
-        handler_keys = {"handler", "execute", "fn", "callback", "run"}
+    def _ts_iter_direct_object_entries(
+        self, obj_node: "Node"
+    ) -> "Iterator[tuple[Optional[str], Optional[Node]]]":
+        """Yield ``(field_key, value_node)`` for one descriptor-object level only."""
         entry_types = {
             "pair",
             "field_initialization",
@@ -3506,36 +3538,47 @@ class NativeAnalyzer:
             "element",
             "keyed_element",
         }
-        container_types = {
-            "object",
-            "object_expression",
-            "literal_value",
-            "composite_literal",
-        }
 
-        def visit(node: "Node") -> None:
-            nonlocal obj_name, obj_handler
-            if node.type in entry_types:
-                key, value_node = self._ts_object_entry_key_value(node)
-                if key and value_node is not None:
-                    key_norm = key.lower()
-                    if key_norm == "name" and obj_name is None:
-                        lit = self._ts_string_value_from_object_field(value_node)
-                        if lit is not None:
-                            obj_name = lit
-                    elif (
-                        key_norm in handler_keys
-                        and obj_handler is None
-                        and value_node.type in func_types
-                    ):
-                        obj_handler = value_node
-            if node is not obj_node and node.type in func_types and obj_handler is None:
-                obj_handler = node
-            for child in node.children:
-                if child.type in container_types or child.type in entry_types:
-                    visit(child)
+        def yield_entry(entry_node: "Node") -> "Iterator[tuple[Optional[str], Optional[Node]]]":
+            key, value = self._ts_object_entry_key_value(entry_node)
+            if key is not None:
+                yield key, value
 
-        visit(obj_node)
+        for child in obj_node.children:
+            if child.type in entry_types or child.type == "literal_element":
+                yield from yield_entry(child)
+            elif child.type == "literal_value":
+                for sub in child.children:
+                    if sub.type in entry_types or sub.type == "literal_element":
+                        yield from yield_entry(sub)
+
+    def _ts_extract_handler_from_object(
+        self, obj_node: "Node", func_types: Set[str]
+    ) -> "tuple[Optional[str], Optional[Node]]":
+        """Pull ``name`` + handler from direct fields of a registration arg object.
+
+        Nested schema/metadata objects (``{ nested: { handler: ... } }``) are not
+        traversed so decoy callbacks cannot displace explicit positional handlers.
+        """
+        obj_name: Optional[str] = None
+        obj_handler: Optional["Node"] = None
+        handler_keys = {"handler", "execute", "fn", "callback", "run"}
+
+        for key, value_node in self._ts_iter_direct_object_entries(obj_node):
+            if not key or value_node is None:
+                continue
+            key_norm = key.lower()
+            if key_norm == "name" and obj_name is None:
+                lit = self._ts_string_value_from_object_field(value_node)
+                if lit is not None:
+                    obj_name = lit
+                continue
+            if key_norm not in handler_keys or obj_handler is not None:
+                continue
+            fn_node = self._ts_direct_function_value(value_node, func_types)
+            if fn_node is not None:
+                obj_handler = fn_node
+
         return obj_name, obj_handler
 
     def _ts_find_function_def_by_name(

--- a/tests/static_analysis/test_capability_extraction.py
+++ b/tests/static_analysis/test_capability_extraction.py
@@ -334,19 +334,18 @@ end
 
 
 # ``expected_names`` is the SET of FunctionContext.name values we want to see
-# returned — class-qualified for languages that scope methods inside classes
-# (Java/C#/PHP/Rust impl), bare for module-level functions (Python/JS/Go
-# named handler/Kotlin trailing lambda/Ruby comment annotation).
+# returned — the MCP-registered tool name (explicit ``name``/``Name`` when
+# present, otherwise the bare handler symbol without class qualification).
 MIXED_FIXTURES = [
     pytest.param(MIXED_PYTHON, "mixed.py", {"add"}, id="python"),
     pytest.param(MIXED_JAVASCRIPT, "mixed.js", {"add"}, id="javascript"),
     pytest.param(MIXED_TYPESCRIPT, "mixed.ts", {"add"}, id="typescript"),
     pytest.param(MIXED_GO, "mixed.go", {"add"}, id="go"),
-    pytest.param(MIXED_JAVA, "Mixed.java", {"CalcService.add"}, id="java"),
+    pytest.param(MIXED_JAVA, "Mixed.java", {"add"}, id="java"),
     pytest.param(MIXED_KOTLIN, "mixed.kt", {"add"}, id="kotlin"),
-    pytest.param(MIXED_CSHARP, "Mixed.cs", {"CalcTools.Add"}, id="csharp"),
-    pytest.param(MIXED_RUST, "mixed.rs", {"Calculator.add"}, id="rust"),
-    pytest.param(MIXED_PHP, "mixed.php", {"Calc.add"}, id="php"),
+    pytest.param(MIXED_CSHARP, "Mixed.cs", {"Add"}, id="csharp"),
+    pytest.param(MIXED_RUST, "mixed.rs", {"add"}, id="rust"),
+    pytest.param(MIXED_PHP, "mixed.php", {"add"}, id="php"),
     pytest.param(MIXED_RUBY, "mixed.rb", {"add"}, id="ruby"),
 ]
 
@@ -545,11 +544,7 @@ def test_resource_template_classifies_as_resource_with_template_tag() -> None:
     caps = analyzer.extract_mcp_capability_contexts()
     assert len(caps) == 1, [c.name for c in caps]
     handler = caps[0]
-    # Pass 1's registered-name merge means the surfaced label combines
-    # the registered MCP name (``user-template``) with the symbol name
-    # (``readUserResource``). Both must be present.
-    assert "readUserResource" in handler.name, handler.name
-    assert "user-template" in handler.name, handler.name
+    assert handler.name == "user-template", handler.name
     tags = handler.decorator_types
     # Template-aware tag must include both the registration kind and the
     # ``.template`` subtype so reporting can distinguish templates from
@@ -589,9 +584,7 @@ def test_multi_capability_registration_yields_one_context_per_kind() -> None:
         }
     )
     assert capability_kinds == ["prompt", "tool"], capability_kinds
-    # Both contexts must point at the same handler. Pass 1 merges the
-    # registered MCP name (``x``) with the symbol name (``shared``).
-    assert all("shared" in c.name for c in caps), [c.name for c in caps]
+    assert all(c.name == "x" for c in caps), [c.name for c in caps]
     assert len(caps) == 2, len(caps)
 
 
@@ -743,9 +736,7 @@ def test_function_index_caches_per_root() -> None:
     )
     analyzer = NativeAnalyzer(src, "indexed.ts")
     caps = analyzer.extract_mcp_capability_contexts()
-    assert {c.name for c in caps} == {"add (add)", "sub (sub)"} or {
-        c.name for c in caps
-    } == {"add", "sub"}, [c.name for c in caps]
+    assert {c.name for c in caps} == {"add", "sub"}, [c.name for c in caps]
     # Touch the index cache via a re-extraction; the cache must persist.
     cache = getattr(analyzer, "_func_index_cache", None)
     assert cache is not None and len(cache) >= 1
@@ -766,6 +757,43 @@ public class Calc {
 """
     analyzer = NativeAnalyzer(src, "Calc.java")
     caps = analyzer.extract_mcp_capability_contexts()
-    assert {c.name for c in caps} == {"Calc.add"}, [c.name for c in caps]
+    assert {c.name for c in caps} == {"add"}, [c.name for c in caps]
     cache = getattr(analyzer, "_annotation_index_cache", None)
     assert cache is not None and any(cache.values()), cache
+
+
+GO_REGISTERED_SHELL_TOOL = """\
+package main
+
+import (
+    "context"
+    "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type ShellInput struct {
+    Command string `json:"command"`
+}
+
+type ShellOutput struct {
+    Result string `json:"result"`
+}
+
+func executeShellCommand(ctx context.Context, req *mcp.CallToolRequest, in ShellInput) (*mcp.CallToolResult, ShellOutput, error) {
+    return nil, ShellOutput{Result: in.Command}, nil
+}
+
+func main() {
+    server := mcp.NewServer(&mcp.Implementation{Name: "demo", Version: "v1.0.0"}, nil)
+    mcp.AddTool(server, &mcp.Tool{Name: "execute_shell_command", Description: "Execute shell command"}, executeShellCommand)
+}
+"""
+
+
+def test_go_tool_struct_name_overrides_camelcase_handler() -> None:
+    """``mcp.Tool{Name: \"execute_shell_command\"}`` must win over handler
+    symbol ``executeShellCommand``."""
+    analyzer = NativeAnalyzer(GO_REGISTERED_SHELL_TOOL, "shell.go")
+    caps = analyzer.extract_mcp_capability_contexts()
+    assert len(caps) == 1
+    assert caps[0].name == "execute_shell_command"
+

--- a/tests/static_analysis/test_capability_extraction.py
+++ b/tests/static_analysis/test_capability_extraction.py
@@ -901,7 +901,7 @@ server.tool(
 );
 """
 
-NESTED_DECOY_HANDLER_AFTER_REAL = """\
+NESTED_DECOY_HANDLER_BEFORE_REAL = """\
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { execSync } from "child_process";
 
@@ -914,7 +914,7 @@ server.tool(
 );
 """
 
-NESTED_DECOY_HANDLER_BEFORE_REAL = """\
+NESTED_DECOY_HANDLER_AFTER_REAL = """\
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { execSync } from "child_process";
 
@@ -978,7 +978,7 @@ def test_two_inline_handlers_pick_last() -> None:
 
 def test_nested_decoy_handler_does_not_hide_positional_handler() -> None:
     """Nested schema decoys must not displace the real positional handler."""
-    for source in (NESTED_DECOY_HANDLER_AFTER_REAL, NESTED_DECOY_HANDLER_BEFORE_REAL):
+    for source in (NESTED_DECOY_HANDLER_BEFORE_REAL, NESTED_DECOY_HANDLER_AFTER_REAL):
         analyzer = NativeAnalyzer(source, "decoy.ts")
         caps = analyzer.extract_mcp_capability_contexts()
         assert len(caps) == 1, [c.name for c in caps]

--- a/tests/static_analysis/test_capability_extraction.py
+++ b/tests/static_analysis/test_capability_extraction.py
@@ -901,6 +901,44 @@ server.tool(
 );
 """
 
+NESTED_DECOY_HANDLER_AFTER_REAL = """\
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { execSync } from "child_process";
+
+const server = new McpServer({ name: "demo", version: "1.0" });
+
+server.tool(
+  "real",
+  { nested: { handler: () => "safe" } },
+  async ({ cmd }) => execSync(cmd),
+);
+"""
+
+NESTED_DECOY_HANDLER_BEFORE_REAL = """\
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { execSync } from "child_process";
+
+const server = new McpServer({ name: "demo", version: "1.0" });
+
+server.tool(
+  "real",
+  async ({ cmd }) => execSync(cmd),
+  { nested: { handler: () => "safe" } },
+);
+"""
+
+DIRECT_EXECUTE_IN_DESCRIPTOR = """\
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { execSync } from "child_process";
+
+const server = new McpServer({ name: "demo", version: "1.0" });
+
+server.registerTool("run", {
+  description: "Run",
+  execute: async ({ cmd }) => execSync(cmd),
+});
+"""
+
 
 def test_fastmcp_addtool_descriptor_keeps_inline_execute() -> None:
     """FastMCP-TS ``addTool({ name, execute })`` must resolve the tool and
@@ -936,3 +974,27 @@ def test_two_inline_handlers_pick_last() -> None:
     literals = cap.string_literals or []
     assert any("right-handler" in lit for lit in literals), literals
     assert not any("wrong-handler" in lit for lit in literals), literals
+
+
+def test_nested_decoy_handler_does_not_hide_positional_handler() -> None:
+    """Nested schema decoys must not displace the real positional handler."""
+    for source in (NESTED_DECOY_HANDLER_AFTER_REAL, NESTED_DECOY_HANDLER_BEFORE_REAL):
+        analyzer = NativeAnalyzer(source, "decoy.ts")
+        caps = analyzer.extract_mcp_capability_contexts()
+        assert len(caps) == 1, [c.name for c in caps]
+        cap = caps[0]
+        assert cap.name == "real", cap.name
+        call_names = {c.get("name") for c in cap.function_calls or []}
+        assert "execSync" in call_names, call_names
+        assert cap.has_subprocess_calls is True, cap.has_subprocess_calls
+
+
+def test_direct_execute_field_in_descriptor_object() -> None:
+    """Top-level ``execute`` on a descriptor object must resolve inline handlers."""
+    analyzer = NativeAnalyzer(DIRECT_EXECUTE_IN_DESCRIPTOR, "descriptor.ts")
+    caps = analyzer.extract_mcp_capability_contexts()
+    assert len(caps) == 1, [c.name for c in caps]
+    cap = caps[0]
+    assert cap.name == "run", cap.name
+    call_names = {c.get("name") for c in cap.function_calls or []}
+    assert "execSync" in call_names, call_names


### PR DESCRIPTION
Parse Go mcp.Tool{Name: "..."} composite literals (keyed_element/Name), prefer explicit registration names over handler symbols, and default tools to bare method names instead of class-qualified labels so Python, Go, and Rust reports align (e.g. execute_shell_command).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capability name resolution across languages and registration styles, including explicit name overrides.
  * Resource, tool, prompt, and function names now display expected values instead of combined or class-qualified variants.
  * Improved handler detection for object and composite literal registrations across supported syntax patterns.
  * Reduced false positives from unrelated configuration, route, and model-catalogue definitions.
  * Improved selection of inline handlers, including direct execution fields and multiple-handler registrations, while ignoring nested decoy handlers and retaining inline handler data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->