### PR TITLE
[AIFW-28548] Route live MCP scans through hybrid proxy relay

### DIFF
--- a/mcpscanner/api/router.py
+++ b/mcpscanner/api/router.py
@@ -55,6 +55,14 @@ router = APIRouter()
 logger = get_logger(__name__)
 
 
+def _hybrid_routing_kwargs(request: APIScanRequest) -> Dict[str, Optional[str]]:
+    """Pass hybrid connector routing from API request into the scanner."""
+    return {
+        "connector_id": request.connector_id,
+        "tenant_id": request.tenant_id,
+    }
+
+
 def get_scanner() -> ScannerFactory:
     """
     Dependency injection placeholder for the ScannerFactory.
@@ -411,6 +419,7 @@ async def scan_tool_endpoint(
             auth=auth,
             analyzers=analyzers,
             http_headers=http_headers,
+            **_hybrid_routing_kwargs(request),
         )
         # Only warn if analyzers actually failed to run
         if len(result.findings) == 0 and len(result.analyzers) == 0:
@@ -501,6 +510,7 @@ async def scan_all_tools_endpoint(
             auth=auth,
             analyzers=analyzers,
             http_headers=http_headers,
+            **_hybrid_routing_kwargs(request),
         )
         logger.debug(f"Scanner completed - scanned {len(results)} tools")
 
@@ -598,6 +608,7 @@ async def scan_prompt_endpoint(
             auth=auth,
             analyzers=analyzers,
             http_headers=http_headers,
+            **_hybrid_routing_kwargs(request),
         )
         logger.debug(f"Scanner completed - scanned prompt: {request.prompt_name}")
 
@@ -674,6 +685,7 @@ async def scan_all_prompts_endpoint(
             auth=auth,
             analyzers=analyzers,
             http_headers=http_headers,
+            **_hybrid_routing_kwargs(request),
         )
         logger.debug(f"Scanner completed - scanned {len(results)} prompts")
 
@@ -770,6 +782,7 @@ async def scan_resource_endpoint(
             analyzers=analyzers,
             http_headers=http_headers,
             allowed_mime_types=allowed_mime_types,
+            **_hybrid_routing_kwargs(request),
         )
         logger.debug(f"Scanner completed - scanned resource: {request.resource_uri}")
 
@@ -856,6 +869,7 @@ async def scan_all_resources_endpoint(
             analyzers=analyzers,
             http_headers=http_headers,
             allowed_mime_types=allowed_mime_types,
+            **_hybrid_routing_kwargs(request),
         )
         logger.debug(f"Scanner completed - scanned {len(results)} resources")
 
@@ -960,6 +974,7 @@ async def scan_instructions_endpoint(
             auth=auth,
             analyzers=analyzers,
             http_headers=http_headers,
+            **_hybrid_routing_kwargs(request),
         )
         logger.debug(f"Scanner completed - scanned instructions from server")
 

--- a/mcpscanner/core/models.py
+++ b/mcpscanner/core/models.py
@@ -337,6 +337,18 @@ class APIScanRequest(BaseModel):
     show_stats: bool = False
     rules_path: Optional[str] = None
     auth: Optional[APIAuthConfig] = None
+    connector_id: Optional[str] = Field(
+        None,
+        description=(
+            "Hybrid connector ID for private MCP servers. When set, the scanner "
+            "dials PROXY_RELAY_URL and forwards the real server_url via "
+            "x-aid-destination-url."
+        ),
+    )
+    tenant_id: Optional[str] = Field(
+        None,
+        description="Tenant ID for hybrid proxy relay routing (x-aid-tenant-id).",
+    )
 
     @field_validator("analyzers")
     @classmethod

--- a/mcpscanner/core/scanner.py
+++ b/mcpscanner/core/scanner.py
@@ -52,6 +52,7 @@ except (
 
 from ..config.config import Config
 from ..utils.logging_config import get_logger
+from ..utils.proxy_relay import is_hybrid_connector_id, prepare_mcp_dial
 from ..utils.command_utils import (
     build_env_for_expansion,
     decide_windows_semantics,
@@ -1372,13 +1373,20 @@ class Scanner:
                     pass
 
     async def _get_mcp_session(
-        self, server_url: str, auth: Optional[Auth] = None
+        self,
+        server_url: str,
+        auth: Optional[Auth] = None,
+        *,
+        connector_id: Optional[str] = None,
+        tenant_id: Optional[str] = None,
     ) -> Tuple[Any, ClientSession]:
         """Create an MCP client session for the given server URL.
 
         Args:
             server_url (str): The URL of the MCP server.
             auth (Optional[Auth]): Explicit authentication configuration. If None, connects without auth.
+            connector_id (Optional[str]): Hybrid connector ID for private MCP servers.
+            tenant_id (Optional[str]): Tenant ID for hybrid proxy relay routing.
 
         Returns:
             tuple: A tuple containing (client_context, session)
@@ -1426,33 +1434,46 @@ class Scanner:
                 f'No explicit auth provided, connecting without authentication: server="{server_url}"'
             )
 
+        destination_url = server_url
+        dial_url, extra_headers = prepare_mcp_dial(
+            destination_url,
+            extra_headers,
+            connector_id,
+            tenant_id,
+            streaming=True,
+        )
+        if is_hybrid_connector_id(connector_id):
+            logger.debug(
+                f'Using hybrid proxy relay for MCP server: destination="{destination_url}"'
+            )
+
         # Create client context with or without OAuth
         # For streamable HTTP, create an explicit httpx.AsyncClient so we can
         # guarantee it gets closed even if the MCP library's internal cleanup
         # fails (e.g. session termination DELETE returns 404).
         httpx_client = None
         if oauth_provider:
-            if "/sse" in server_url:
-                client_context = sse_client(server_url, auth=oauth_provider)
+            if "/sse" in destination_url:
+                client_context = sse_client(dial_url, auth=oauth_provider)
             else:
                 httpx_client = create_mcp_http_client(auth=oauth_provider)
-                client_context = streamable_http_client(server_url, http_client=httpx_client)
+                client_context = streamable_http_client(dial_url, http_client=httpx_client)
         else:
             logger.debug(
-                f'Using standard connection (no auth) for MCP server: server="{server_url}"'
+                f'Using standard connection (no auth) for MCP server: server="{destination_url}"'
             )
             # Pass bearer Authorization header when requested
-            if "/sse" in server_url:
+            if "/sse" in destination_url:
                 client_context = (
-                    sse_client(server_url, headers=extra_headers)
+                    sse_client(dial_url, headers=extra_headers)
                     if extra_headers
-                    else sse_client(server_url)
+                    else sse_client(dial_url)
                 )
             else:
                 httpx_client = create_mcp_http_client(
                     headers=extra_headers if extra_headers else None
                 )
-                client_context = streamable_http_client(server_url, http_client=httpx_client)
+                client_context = streamable_http_client(dial_url, http_client=httpx_client)
 
         # Stash the httpx client on the context so _close_mcp_session can close it
         client_context._httpx_client = httpx_client
@@ -1608,6 +1629,8 @@ class Scanner:
         auth: Optional[Auth] = None,
         analyzers: Optional[List[AnalyzerEnum]] = None,
         http_headers: Optional[dict] = None,
+        connector_id: Optional[str] = None,
+        tenant_id: Optional[str] = None,
     ) -> ToolScanResult:
         """Scan a specific tool on an MCP server.
 
@@ -1638,7 +1661,12 @@ class Scanner:
         client_context = None
         session = None
         try:
-            client_context, session = await self._get_mcp_session(server_url, auth)
+            client_context, session = await self._get_mcp_session(
+                server_url,
+                auth,
+                connector_id=connector_id,
+                tenant_id=tenant_id,
+            )
 
             # List all tools and find the target tool
             try:
@@ -1682,6 +1710,8 @@ class Scanner:
         auth: Optional[Auth] = None,
         analyzers: Optional[List[AnalyzerEnum]] = None,
         http_headers: Optional[dict] = None,
+        connector_id: Optional[str] = None,
+        tenant_id: Optional[str] = None,
     ) -> List[ToolScanResult]:
         """Scan all tools on an MCP server.
 
@@ -1715,7 +1745,12 @@ class Scanner:
         client_context = None
         session = None
         try:
-            client_context, session = await self._get_mcp_session(server_url, auth)
+            client_context, session = await self._get_mcp_session(
+                server_url,
+                auth,
+                connector_id=connector_id,
+                tenant_id=tenant_id,
+            )
 
             # List all tools
             try:
@@ -2265,6 +2300,8 @@ class Scanner:
         auth: Optional[Auth] = None,
         analyzers: Optional[List[AnalyzerEnum]] = None,
         http_headers: Optional[dict] = None,
+        connector_id: Optional[str] = None,
+        tenant_id: Optional[str] = None,
     ) -> List[PromptScanResult]:
         """Scan all prompts on an MCP server.
 
@@ -2298,7 +2335,12 @@ class Scanner:
         client_context = None
         session = None
         try:
-            client_context, session = await self._get_mcp_session(server_url, auth)
+            client_context, session = await self._get_mcp_session(
+                server_url,
+                auth,
+                connector_id=connector_id,
+                tenant_id=tenant_id,
+            )
 
             # Capability gate: see scan_remote_server_resources for rationale.
             if self._server_supports_capability(session, "prompts") is False:
@@ -2357,6 +2399,8 @@ class Scanner:
         auth: Optional[Auth] = None,
         analyzers: Optional[List[AnalyzerEnum]] = None,
         http_headers: Optional[dict] = None,
+        connector_id: Optional[str] = None,
+        tenant_id: Optional[str] = None,
     ) -> PromptScanResult:
         """Scan a specific prompt on an MCP server.
 
@@ -2388,7 +2432,12 @@ class Scanner:
         client_context = None
         session = None
         try:
-            client_context, session = await self._get_mcp_session(server_url, auth)
+            client_context, session = await self._get_mcp_session(
+                server_url,
+                auth,
+                connector_id=connector_id,
+                tenant_id=tenant_id,
+            )
 
             # Capability gate (same rationale as scan_remote_server_prompts).
             if self._server_supports_capability(session, "prompts") is False:
@@ -2438,6 +2487,8 @@ class Scanner:
         auth: Optional[Auth] = None,
         analyzers: Optional[List[AnalyzerEnum]] = None,
         http_headers: Optional[dict] = None,
+        connector_id: Optional[str] = None,
+        tenant_id: Optional[str] = None,
     ) -> InstructionsScanResult:
         """Scan server instructions from the InitializeResult.
 
@@ -2469,7 +2520,12 @@ class Scanner:
         client_context = None
         session = None
         try:
-            client_context, session = await self._get_mcp_session(server_url, auth)
+            client_context, session = await self._get_mcp_session(
+                server_url,
+                auth,
+                connector_id=connector_id,
+                tenant_id=tenant_id,
+            )
 
             # Get the initialize result which was stored during session initialization
             init_result = getattr(session, "_init_result", None)
@@ -2852,6 +2908,8 @@ class Scanner:
         analyzers: Optional[List[AnalyzerEnum]] = None,
         http_headers: Optional[dict] = None,
         allowed_mime_types: Optional[List[str]] = None,
+        connector_id: Optional[str] = None,
+        tenant_id: Optional[str] = None,
     ) -> List[ResourceScanResult]:
         """Scan all resources on an MCP server.
 
@@ -2890,7 +2948,12 @@ class Scanner:
         client_context = None
         session = None
         try:
-            client_context, session = await self._get_mcp_session(server_url, auth)
+            client_context, session = await self._get_mcp_session(
+                server_url,
+                auth,
+                connector_id=connector_id,
+                tenant_id=tenant_id,
+            )
 
             # Capability gate: if the InitializeResult didn't advertise
             # resources support, don't bother calling list_resources — many
@@ -3051,6 +3114,8 @@ class Scanner:
         analyzers: Optional[List[AnalyzerEnum]] = None,
         http_headers: Optional[dict] = None,
         allowed_mime_types: Optional[List[str]] = None,
+        connector_id: Optional[str] = None,
+        tenant_id: Optional[str] = None,
     ) -> ResourceScanResult:
         """Scan a specific resource on an MCP server.
 
@@ -3095,7 +3160,12 @@ class Scanner:
         client_context = None
         session = None
         try:
-            client_context, session = await self._get_mcp_session(server_url, auth)
+            client_context, session = await self._get_mcp_session(
+                server_url,
+                auth,
+                connector_id=connector_id,
+                tenant_id=tenant_id,
+            )
 
             # Capability gate (same rationale as scan_remote_server_resources).
             if self._server_supports_capability(session, "resources") is False:

--- a/mcpscanner/core/scanner.py
+++ b/mcpscanner/core/scanner.py
@@ -1454,9 +1454,16 @@ class Scanner:
         httpx_client = None
         if oauth_provider:
             if "/sse" in destination_url:
-                client_context = sse_client(dial_url, auth=oauth_provider)
+                client_context = (
+                    sse_client(dial_url, headers=extra_headers, auth=oauth_provider)
+                    if extra_headers
+                    else sse_client(dial_url, auth=oauth_provider)
+                )
             else:
-                httpx_client = create_mcp_http_client(auth=oauth_provider)
+                httpx_client = create_mcp_http_client(
+                    headers=extra_headers if extra_headers else None,
+                    auth=oauth_provider,
+                )
                 client_context = streamable_http_client(dial_url, http_client=httpx_client)
         else:
             logger.debug(

--- a/mcpscanner/utils/proxy_relay.py
+++ b/mcpscanner/utils/proxy_relay.py
@@ -1,0 +1,103 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Proxy relay routing helpers for hybrid (private connector) MCP access.
+
+Mirrors ai-firewall-services/mcp_scan_worker/proxy_relay.py so live security
+scans can reach private MCP servers through cloud-gateway proxy relay.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional, Tuple
+
+HEADER_DESTINATION_URL = "x-aid-destination-url"
+HEADER_CONNECTOR_ID = "x-aid-connector-id"
+HEADER_TENANT_ID = "x-aid-tenant-id"
+HEADER_STREAMING = "X-Aid-Streaming"
+ENV_PROXY_RELAY_URL = "PROXY_RELAY_URL"
+
+# Aligns with mcp_registry/connectorutil dummy / nil connector IDs.
+NIL_CONNECTOR_ID = "00000000-0000-0000-0000-000000000000"
+
+
+def is_hybrid_connector_id(connector_id: Optional[str]) -> bool:
+    """Return True when connector_id denotes a private (hybrid) data plane."""
+    connector_id = (connector_id or "").strip()
+    if not connector_id:
+        return False
+    return connector_id != NIL_CONNECTOR_ID
+
+
+def _normalized_proxy_relay_url() -> str:
+    proxy_relay_url = os.environ.get(ENV_PROXY_RELAY_URL, "").strip()
+    if not proxy_relay_url:
+        raise RuntimeError(
+            f"{ENV_PROXY_RELAY_URL} is not configured for hybrid MCP access"
+        )
+    if not proxy_relay_url.startswith(("http://", "https://")):
+        proxy_relay_url = f"http://{proxy_relay_url}"
+    return proxy_relay_url
+
+
+def proxy_relay_dial_url() -> str:
+    """Return the proxy relay endpoint to dial for hybrid requests."""
+    return _normalized_proxy_relay_url()
+
+
+def proxy_relay_headers(
+    destination_url: str,
+    headers: Dict[str, str],
+    connector_id: Optional[str],
+    tenant_id: Optional[str],
+    *,
+    streaming: bool = False,
+) -> Dict[str, str]:
+    """Inject proxy-relay routing headers for hybrid (connector) requests."""
+    if not is_hybrid_connector_id(connector_id):
+        return headers
+
+    connector_id = (connector_id or "").strip()
+    out_headers = dict(headers)
+    out_headers[HEADER_DESTINATION_URL] = destination_url
+    out_headers[HEADER_CONNECTOR_ID] = connector_id
+    if tenant_id:
+        out_headers[HEADER_TENANT_ID] = tenant_id.strip()
+    if streaming:
+        out_headers[HEADER_STREAMING] = "true"
+    return out_headers
+
+
+def prepare_mcp_dial(
+    server_url: str,
+    headers: Dict[str, str],
+    connector_id: Optional[str],
+    tenant_id: Optional[str],
+    *,
+    streaming: bool = False,
+) -> Tuple[str, Dict[str, str]]:
+    """Return the MCP client dial URL and headers for SaaS or hybrid routing."""
+    out_headers = proxy_relay_headers(
+        server_url,
+        headers,
+        connector_id,
+        tenant_id,
+        streaming=streaming,
+    )
+    if is_hybrid_connector_id(connector_id):
+        return proxy_relay_dial_url(), out_headers
+    return server_url, out_headers

--- a/mcpscanner/utils/proxy_relay.py
+++ b/mcpscanner/utils/proxy_relay.py
@@ -44,6 +44,12 @@ def is_hybrid_connector_id(connector_id: Optional[str]) -> bool:
 
 
 def _normalized_proxy_relay_url() -> str:
+    """Return PROXY_RELAY_URL with an explicit scheme.
+
+    Scheme-less values default to ``http://`` to match
+    ``mcp_scan_worker/proxy_relay.py`` and in-cluster Helm config
+    (``host:port`` on the pod network, not the public internet).
+    """
     proxy_relay_url = os.environ.get(ENV_PROXY_RELAY_URL, "").strip()
     if not proxy_relay_url:
         raise RuntimeError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-ai-mcp-scanner"
-version = "4.7.5"
+version = "4.7.6"
 description = "A tool to scan MCP servers and tools for security findings"
 authors = [
     {name = "Cisco"},

--- a/tests/test_proxy_relay.py
+++ b/tests/test_proxy_relay.py
@@ -1,0 +1,104 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import patch
+
+from mcpscanner.utils.proxy_relay import (
+    HEADER_CONNECTOR_ID,
+    HEADER_DESTINATION_URL,
+    HEADER_STREAMING,
+    HEADER_TENANT_ID,
+    NIL_CONNECTOR_ID,
+    is_hybrid_connector_id,
+    prepare_mcp_dial,
+    proxy_relay_headers,
+)
+
+
+class TestIsHybridConnectorID:
+    def test_empty_is_saas(self):
+        assert is_hybrid_connector_id(None) is False
+        assert is_hybrid_connector_id("") is False
+        assert is_hybrid_connector_id("   ") is False
+
+    def test_nil_uuid_is_saas(self):
+        assert is_hybrid_connector_id(NIL_CONNECTOR_ID) is False
+
+    def test_real_connector_is_hybrid(self):
+        assert is_hybrid_connector_id("42cab0eb-3d55-4097-b0db-1ae5099da63b") is True
+
+
+class TestProxyRelayHeaders:
+    def test_saas_returns_headers_unchanged(self):
+        headers = {"User-Agent": "test"}
+        out = proxy_relay_headers(
+            "http://example.com/sse",
+            headers,
+            connector_id=None,
+            tenant_id=None,
+        )
+        assert out == headers
+
+    @patch(
+        "mcpscanner.utils.proxy_relay.proxy_relay_dial_url",
+        return_value="http://proxy-relay:5600",
+    )
+    def test_hybrid_injects_routing_headers(self, _mock_dial_url):
+        headers = {"User-Agent": "test"}
+        out = proxy_relay_headers(
+            "http://host.docker.internal:8765/success",
+            headers,
+            connector_id="42cab0eb-3d55-4097-b0db-1ae5099da63b",
+            tenant_id="192caeea-9955-44a9-8ef4-19006f5beb10",
+            streaming=True,
+        )
+        assert out[HEADER_DESTINATION_URL] == "http://host.docker.internal:8765/success"
+        assert out[HEADER_CONNECTOR_ID] == "42cab0eb-3d55-4097-b0db-1ae5099da63b"
+        assert out[HEADER_TENANT_ID] == "192caeea-9955-44a9-8ef4-19006f5beb10"
+        assert out[HEADER_STREAMING] == "true"
+        assert out["User-Agent"] == "test"
+
+
+class TestPrepareMcpDial:
+    @patch(
+        "mcpscanner.utils.proxy_relay.proxy_relay_dial_url",
+        return_value="http://proxy-relay:5600",
+    )
+    def test_saas_uses_direct_url(self, _mock_dial_url):
+        dial_url, headers = prepare_mcp_dial(
+            "https://public.example.com/sse",
+            {},
+            connector_id=None,
+            tenant_id=None,
+        )
+        assert dial_url == "https://public.example.com/sse"
+        assert headers == {}
+
+    @patch(
+        "mcpscanner.utils.proxy_relay.proxy_relay_dial_url",
+        return_value="http://proxy-relay:5600",
+    )
+    def test_hybrid_uses_relay(self, _mock_dial_url):
+        destination = "http://host.docker.internal:8765/success"
+        dial_url, headers = prepare_mcp_dial(
+            destination,
+            {},
+            connector_id="42cab0eb-3d55-4097-b0db-1ae5099da63b",
+            tenant_id="tenant-1",
+            streaming=True,
+        )
+        assert dial_url == "http://proxy-relay:5600"
+        assert headers[HEADER_DESTINATION_URL] == destination

--- a/tests/test_proxy_relay.py
+++ b/tests/test_proxy_relay.py
@@ -16,14 +16,19 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from mcpscanner.utils.proxy_relay import (
+    ENV_PROXY_RELAY_URL,
     HEADER_CONNECTOR_ID,
     HEADER_DESTINATION_URL,
     HEADER_STREAMING,
     HEADER_TENANT_ID,
     NIL_CONNECTOR_ID,
+    _normalized_proxy_relay_url,
     is_hybrid_connector_id,
     prepare_mcp_dial,
+    proxy_relay_dial_url,
     proxy_relay_headers,
 )
 
@@ -102,3 +107,23 @@ class TestPrepareMcpDial:
         )
         assert dial_url == "http://proxy-relay:5600"
         assert headers[HEADER_DESTINATION_URL] == destination
+
+
+class TestNormalizedProxyRelayURL:
+    def test_missing_env_raises(self, monkeypatch):
+        monkeypatch.delenv(ENV_PROXY_RELAY_URL, raising=False)
+        with pytest.raises(RuntimeError, match=f"{ENV_PROXY_RELAY_URL} is not configured"):
+            _normalized_proxy_relay_url()
+
+    def test_scheme_less_defaults_to_http(self, monkeypatch):
+        monkeypatch.setenv(ENV_PROXY_RELAY_URL, "cloud-gateway:5600")
+        assert _normalized_proxy_relay_url() == "http://cloud-gateway:5600"
+        assert proxy_relay_dial_url() == "http://cloud-gateway:5600"
+
+    def test_explicit_http_preserved(self, monkeypatch):
+        monkeypatch.setenv(ENV_PROXY_RELAY_URL, "http://cloud-gateway:5600")
+        assert _normalized_proxy_relay_url() == "http://cloud-gateway:5600"
+
+    def test_explicit_https_preserved(self, monkeypatch):
+        monkeypatch.setenv(ENV_PROXY_RELAY_URL, "https://relay.example.com")
+        assert _normalized_proxy_relay_url() == "https://relay.example.com"

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -746,7 +746,12 @@ async def test_scan_remote_server_tool_with_auth(config):
         )
 
         assert result.tool_name == "auth_tool"
-        mock_get_session.assert_called_once_with("https://test.com", auth)
+        mock_get_session.assert_called_once_with(
+            "https://test.com",
+            auth,
+            connector_id=None,
+            tenant_id=None,
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add `prepare_mcp_dial()` to cisco-ai-mcp-scanner so live YARA/LLM scans can reach private MCP servers via cloud-gateway proxy relay.
- Accept `connector_id` and `tenant_id` on scan API requests (already sent by mcp-scan-mgr).
- Bump package version to 4.7.6.

## Context

Jira: https://cisco-sbg.atlassian.net/browse/AIFW-28548 (epic AIFW-24114)

Hybrid validate/fetch already route through `PROXY_RELAY_URL` in `mcp_scan_worker`. Live security scans failed because the scanner dialed private `server_url` values directly from the cluster — `connector_id` / `tenant_id` in the HTTP body were ignored.

## Changes

- `mcpscanner/utils/proxy_relay.py` — hybrid routing helpers (aligned with `mcp_scan_worker/proxy_relay.py`)
- `APIScanRequest` — optional `connector_id`, `tenant_id`
- `Scanner._get_mcp_session()` — dial via relay when hybrid connector is set
- FastAPI scan endpoints — pass routing into scanner
- `tests/test_proxy_relay.py`

## Test plan

- [x] `uv run pytest tests/test_proxy_relay.py`
- [ ] Hybrid E2E: register private MCP with `scanEnabled: true` → scan summary `completedAt` set (not Failed)
- [ ] SaaS regression: scan public MCP without `connector_id`

## Follow-up

- Bump `cisco-ai-mcp-scanner` to 4.7.6 in `ai-firewall-services/mcp_scan_worker` after merge/release

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hybrid proxy relay routing for scan requests using optional `connector_id` and `tenant_id`.
  * Extended remote scanning for tools, prompts, resources, and instructions to pass the new routing parameters through.
* **Tests**
  * Added coverage for proxy relay URL normalization and dial/header preparation behavior.
* **Chores**
  * Bumped the package version to 4.7.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->