### PR TITLE
chore: bump version to 4.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cisco-ai-mcp-scanner"
-version = "4.8.0"
+version = "4.8.1"
 description = "A tool to scan MCP servers and tools for security findings"
 authors = [
     {name = "Cisco"},

--- a/uv.lock
+++ b/uv.lock
@@ -393,7 +393,7 @@ wheels = [
 
 [[package]]
 name = "cisco-ai-mcp-scanner"
-version = "4.8.0"
+version = "4.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "expandvars" },


### PR DESCRIPTION
Patch release after the litellm 1.93.0 dependency update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package release version from 4.8.0 to 4.8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->