### PR TITLE
fix: relax litellm exact pin from ==1.93.0 to >=1.83.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-﻿[build-system]
+[build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "uvicorn>=0.29.0",
     "pydantic>=2.6.0",
     "python-dotenv>=1.0.0",
-    "litellm>=1.83.7",
+    "litellm>=1.84.0",
     "expandvars>=0.12.0",
     # JS/TS parsing for npm behavioral analysis pins the shared tree-sitter
     # runtime to a tested ABI range (other language packs stay >=0.21.0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-[build-system]
+﻿[build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
@@ -26,7 +26,7 @@ dependencies = [
     "uvicorn>=0.29.0",
     "pydantic>=2.6.0",
     "python-dotenv>=1.0.0",
-    "litellm==1.93.0",
+    "litellm>=1.83.7",
     "expandvars>=0.12.0",
     # JS/TS parsing for npm behavioral analysis pins the shared tree-sitter
     # runtime to a tested ABI range (other language packs stay >=0.21.0,


### PR DESCRIPTION
Fixes #212.

The exact pin prevents installs in any environment that also pulls a package needing modern python-dotenv >=1.1.0 (e.g. fastmcp >=3.0). The resolver fails because older litellm versions transitively pinned python-dotenv exactly.

Change: \litellm==1.93.0\ → \litellm>=1.83.7\.

Keeping \>=1.83.7\ as a lower-bound floor preserves the proxy API-key SQL-injection fix that motivated the pin, while letting the resolver pick a modern release whose python-dotenv constraint is compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project version (4.8.1 → 4.8.2).
  * Adjusted the LiteLLM dependency from a fully pinned release to a lower-bounded version constraint to improve installation flexibility.
  * No user-facing features, workflows, or configurations were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->