### PR TITLE
fix(meta-analyzer): use Config llm_temperature instead of hardcoded 0.1

### DIFF
--- a/mcpscanner/core/analyzers/meta_analyzer.py
+++ b/mcpscanner/core/analyzers/meta_analyzer.py
@@ -171,6 +171,7 @@ class MetaAnalyzer:
         """Initialize the Meta Analyzer.
 
         Uses the same LLM configuration as the LLM analyzer (from Config),
+        including ``llm_temperature`` (``MCP_SCANNER_DEFAULT_LLM_TEMPERATURE``),
         with higher max_tokens and timeout for the larger meta-analysis payloads.
 
         Args:
@@ -226,7 +227,7 @@ class MetaAnalyzer:
         # schema is small), but it's exposed for tests / future config
         # wiring rather than living as a magic number.
         self._max_tokens = 8192
-        self._temperature = 0.1
+        self._temperature = config.llm_temperature
         self._max_retries = config.llm_max_retries
         configured_timeout = float(config.llm_timeout or 0.0)
         recommended_floor = 60.0

--- a/tests/test_meta_analyzer.py
+++ b/tests/test_meta_analyzer.py
@@ -150,8 +150,14 @@ class TestMetaAnalyzerInit:
         analyzer = MetaAnalyzer(config)
         assert analyzer.name == "META"
         assert analyzer._model == config.llm_model
-        assert analyzer._temperature == 0.1
+        assert analyzer._temperature == config.llm_temperature
         assert analyzer._max_tokens == 8192
+
+    def test_init_uses_config_llm_temperature(self):
+        """MetaAnalyzer honours Config.llm_temperature (incl. MCP_SCANNER_DEFAULT_LLM_TEMPERATURE)."""
+        config = _make_config(llm_temperature=0.5)
+        analyzer = MetaAnalyzer(config)
+        assert analyzer._temperature == 0.5
 
     def test_init_without_api_key_raises(self):
         """MetaAnalyzer raises ValueError without an API key."""


### PR DESCRIPTION
MetaAnalyzer now reads temperature from the same Config/env path as LLMAnalyzer (MCP_SCANNER_DEFAULT_LLM_TEMPERATURE), so operators can tune both passes consistently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Meta-analysis now consistently uses the configured LLM temperature, including custom temperature settings.
  * Improved configuration consistency prevents unexpected sampling behavior during analysis.

* **Tests**
  * Added coverage to verify both default and overridden LLM temperature settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->