### PR TITLE
fix(scanner): stop YARA from stripping description off the shared tool_data

### DIFF
--- a/mcpscanner/core/scanner.py
+++ b/mcpscanner/core/scanner.py
@@ -912,10 +912,17 @@ class Scanner:
 
             # Run YARA analysis on the tool parameters
             try:
-                # Remove description from the JSON as it is already analyzed
-                if "description" in tool_data:
-                    del tool_data["description"]
-                tool_json_str = json.dumps(tool_data)
+                # Remove description from the JSON as it is already analyzed.
+                # Build a view for YARA instead of mutating tool_data: later
+                # branches (notably READINESS, which reads the tool definition
+                # from context) must see the tool exactly as the server
+                # declared it, not as an earlier analyzer left it.
+                yara_params_data = {
+                    key: value
+                    for key, value in tool_data.items()
+                    if key != "description"
+                }
+                tool_json_str = json.dumps(yara_params_data)
                 yara_params_context = {"tool_name": name, "content_type": "parameters"}
                 yara_params_findings = await self._yara_analyzer.analyze(
                     tool_json_str, yara_params_context

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -16,6 +16,7 @@
 
 # tests/test_scanner.py
 
+import json
 import pytest
 import respx
 from unittest.mock import patch, AsyncMock, MagicMock
@@ -1305,3 +1306,65 @@ async def test_scan_prompts_returns_empty_on_synthetic_session_terminated(config
 
     assert results == []
     session.list_prompts.assert_called_once()
+
+
+# --- Regression: analyzers must not corrupt each other's input (issue #227) ---
+
+
+@pytest.mark.asyncio
+async def test_yara_does_not_strip_description_from_readiness_input():
+    """YARA's parameter scan must not mutate the tool definition READINESS sees.
+
+    The YARA branch drops `description` before scanning parameters. When that
+    deletion happened on the dict shared with later branches, READINESS
+    received a description-less tool definition and HEUR-009 ("no description")
+    fired for every tool of every server scanned with the default analyzer
+    set — a finding that depended on which *other* analyzer ran, and that no
+    server operator could remediate.
+    """
+    from mcp.types import Tool as MCPTool
+
+    tool = MCPTool(
+        name="documented_tool",
+        description="A thoroughly documented tool that lists open pull requests.",
+        inputSchema={
+            "type": "object",
+            "properties": {"repo": {"type": "string"}},
+            "required": ["repo"],
+        },
+    )
+
+    seen = {}
+
+    async def capture_readiness(content, context=None):
+        seen["content"] = content
+        seen["context"] = context
+        return []
+
+    async def noop_yara(content, context=None):
+        seen.setdefault("yara_payloads", []).append(content)
+        return []
+
+    scanner = Scanner(Config(api_key="test_api_key"))
+    scanner._yara_analyzer = MagicMock()
+    scanner._yara_analyzer.analyze = AsyncMock(side_effect=noop_yara)
+    scanner._readiness_analyzer = MagicMock()
+    scanner._readiness_analyzer.analyze = AsyncMock(side_effect=capture_readiness)
+
+    await scanner._analyze_tool(
+        tool, [AnalyzerEnum.YARA, AnalyzerEnum.READINESS]
+    )
+
+    # READINESS resolves the tool definition from context first, so that is
+    # the value that must still carry the description.
+    tool_definition = seen["context"]["tool_definition"]
+    assert tool_definition["description"] == tool.description
+    assert json.loads(seen["content"])["description"] == tool.description
+
+    # YARA still gets its description-free parameter payload, and drops
+    # nothing else. Compared as key sets so this does not depend on whether
+    # the MCP model serialises field names or aliases.
+    params_payload = json.loads(seen["yara_payloads"][-1])
+    full_payload = json.loads(tool.model_dump_json())
+    assert "description" not in params_payload
+    assert set(params_payload) == set(full_payload) - {"description"}


### PR DESCRIPTION
Closes #227. Root cause and line numbers are @avoskresensky's diagnosis; I verified all three against current `main` and added the regression test.

## The defect

`_analyze_tool` builds a single `tool_data` dict (`scanner.py:881`) that every analyzer branch shares. The YARA parameters branch deleted `description` from it in place, and the READINESS branch then passed that same dict as `context["tool_definition"]`. Since `ReadinessAnalyzer._parse_tool_definition` prefers the context value over the `content` argument, HEUR-009 saw an empty description and fired for **every tool of every server** scanned with the default yara+readiness set — a finding that depended on which *other* analyzer ran, and that no server operator could remediate.

## The fix

Build YARA's description-free payload as a separate view rather than mutating the shared dict. YARA keeps its original behaviour (parameters scanned without the description, which is already scanned separately just above); every later branch sees the tool as the server declared it.

I kept this to the one-line-scope defect rather than introducing a defensive `deepcopy` at the top of `_analyze_tool`. Happy to go the broader route if you'd prefer an explicit immutability contract for `tool_data` — the shape of this bug (analyzer A silently corrupting analyzer B's input) is the kind that recurs, so a structural guard is defensible. Just didn't want to expand the diff without a maintainer preference.

## Verification

New test `test_yara_does_not_strip_description_from_readiness_input` asserts the isolation directly: it captures what READINESS actually receives and checks the description survives, while confirming YARA still gets its description-free payload with nothing else dropped.

- **Without the fix:** the new test fails (`KeyError` on the description READINESS should have seen).
- **With the fix:** passes.
- **Full file:** `54 passed` (53 existing + this one).

Two pre-existing failures in `tests/test_scanner.py` (`test_scan_resources_returns_empty_on_synthetic_session_terminated`, `test_scan_prompts_returns_empty_on_synthetic_session_terminated`) reproduce identically on a clean `main` checkout in my environment and are unrelated to this change — see the note below, which may be the cause.

## Unrelated observation, flagging rather than fixing

While writing the test I noticed that `pyproject.toml` pins `mcp[cli]>=1.25.0`, so a fresh install currently resolves **mcp 2.0.0**. Under 2.0.0, `MCPTool.model_dump_json()` serialises field names rather than aliases, so `tool_data` carries `input_schema`, not `inputSchema`. That makes the check at `scanner.py:937`

```python
if "inputSchema" in tool_data:
```

always false, so the LLM branch silently omits the parameter schema from its analysis content. I have not confirmed the behaviour under mcp 1.x and it is out of scope here, so I've left it alone — but it looked worth a maintainer's attention, and it may also explain the two pre-existing test failures above. Happy to open a separate issue if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved tool descriptions during readiness analysis after YARA analysis runs.
  * Ensured different analysis stages receive the correct, independent tool data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->