### PR TITLE
fix(scanner): stop YARA from blanking description for READINESS

### DIFF
--- a/mcpscanner/core/scanner.py
+++ b/mcpscanner/core/scanner.py
@@ -912,10 +912,12 @@ class Scanner:
 
             # Run YARA analysis on the tool parameters
             try:
-                # Remove description from the JSON as it is already analyzed
-                if "description" in tool_data:
-                    del tool_data["description"]
-                tool_json_str = json.dumps(tool_data)
+                # Remove description from a copy of tool_data, since it is
+                # already analyzed above. tool_data itself must stay intact
+                # for later analyzers (e.g. READINESS) that reuse it.
+                yara_tool_data = dict(tool_data)
+                yara_tool_data.pop("description", None)
+                tool_json_str = json.dumps(yara_tool_data)
                 yara_params_context = {"tool_name": name, "content_type": "parameters"}
                 yara_params_findings = await self._yara_analyzer.analyze(
                     tool_json_str, yara_params_context

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -440,6 +440,33 @@ async def test_analyze_tool_with_yara_analyzer(config):
 
 
 @pytest.mark.asyncio
+async def test_analyze_tool_yara_does_not_blank_description_for_readiness(config):
+    """Regression test: YARA's parameter scan used to delete 'description'
+    from the tool_data dict shared with READINESS, so every tool looked
+    description-less to READINESS (HEUR-009 false positive) regardless of
+    combined analyzer order. YARA must scan a copy, leaving tool_data intact
+    for analyzers that run after it."""
+    long_description = (
+        "Fetches the current weather forecast for a given city and date range."
+    )
+    mock_tool = MCPTool(name="test_tool", description=long_description)
+
+    with patch.object(YaraAnalyzer, "analyze", return_value=[]):
+        scanner = Scanner(config)
+        result = await scanner._analyze_tool(
+            mock_tool, [AnalyzerEnum.YARA, AnalyzerEnum.READINESS]
+        )
+
+    assert result.tool_name == "test_tool"
+    heur_009_findings = [
+        f
+        for f in result.findings
+        if f.analyzer == "READINESS" and f.details.get("rule_id") == "HEUR-009"
+    ]
+    assert heur_009_findings == []
+
+
+@pytest.mark.asyncio
 async def test_analyze_tool_with_custom_analyzer(config):
     """Test _analyze_tool method with custom analyzer."""
     mock_tool = MCPTool(name="test_tool", description="malicious content")


### PR DESCRIPTION
## Summary

Fixes #227.

`Scanner._analyze_tool` builds one `tool_data` dict (`json.loads(tool.model_dump_json())`) and reuses it across analyzer branches. The YARA-parameters branch deleted `"description"` from that dict in place before scanning parameters:

```python
if "description" in tool_data:
    del tool_data["description"]
```

`tool_data` is the same object later passed as `readiness_context["tool_definition"]`. Since `ReadinessAnalyzer._parse_tool_definition` prefers `context["tool_definition"]` when present, READINESS always received a description-less tool definition whenever YARA ran first in the analyzer list — regardless of how good the tool's real description is. That guarantees a HEUR-009 ("vague description") finding on every tool scanned with the default `yara,readiness` analyzer combination.

## Fix

YARA's parameter scan now works on its own shallow copy instead of mutating the shared dict:

```python
yara_tool_data = dict(tool_data)
yara_tool_data.pop("description", None)
tool_json_str = json.dumps(yara_tool_data)
```

`tool_data` itself is left untouched for the READINESS branch (and any other later consumer).

## Tests

Added `test_analyze_tool_yara_does_not_blank_description_for_readiness` in `tests/test_scanner.py`, which runs `_analyze_tool` with `[AnalyzerEnum.YARA, AnalyzerEnum.READINESS]` on a tool with a normal, detailed description and asserts no HEUR-009 finding is produced.

```
.venv/bin/python -m pytest tests/test_scanner.py tests/readiness/ -q
```
136 passed (2 pre-existing, unrelated `Session terminated` mock failures reproduce identically on a clean checkout of `main` — not touched by this change).

Full suite: `1236 passed, 11 skipped`, with 3 pre-existing failures (the 2 above plus one FastAPI/Starlette-version-drift failure in `test_instructions_scanning.py`) all independently reproducing on a clean `main` checkout in the same environment, unrelated to the two files this PR touches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool analysis consistency by preserving descriptions for all applicable checks.
  * Prevented incorrect readiness warnings caused by analyzer order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->