### PR TITLE
Fix : TS dynamic tool registration extraction for wrappers 

### DIFF
--- a/mcpscanner/core/analyzers/behavioral/js_code_analyzer.py
+++ b/mcpscanner/core/analyzers/behavioral/js_code_analyzer.py
@@ -40,6 +40,9 @@ from typing import Any, Dict, List, Optional
 from ....config.config import Config
 from ....config.constants import MCPScannerConstants
 from ....threats.threats import ThreatMapping
+from ...static_analysis.interprocedural.treesitter_call_graph import (
+    TreeSitterCallGraphAnalyzer,
+)
 from ..base import BaseAnalyzer, SecurityFinding
 from .alignment import AlignmentOrchestrator
 
@@ -55,6 +58,18 @@ _JS_EXTENSIONS = (".js", ".mjs", ".cjs", ".jsx", ".ts", ".mts", ".cts", ".tsx")
 _SKIP_DIRS = frozenset(
     {"node_modules", "dist", "build", "out", ".git", ".next", ".turbo", "coverage"}
 )
+
+# Keep in sync with ``BehavioralCodeAnalyzer._EXT_TO_TS_LANGUAGE`` for JS/TS.
+_EXT_TO_TS_LANGUAGE = {
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".mts": "typescript",
+    ".cts": "typescript",
+}
 
 
 class JSBehavioralCodeAnalyzer(BaseAnalyzer):
@@ -127,9 +142,14 @@ class JSBehavioralCodeAnalyzer(BaseAnalyzer):
         self.logger.debug(
             "js behavioural scan root=%s files=%d", directory, len(files)
         )
+        call_graphs = self._build_directory_call_graphs(files)
         findings: List[SecurityFinding] = []
         for path in files:
-            file_findings = await self._analyze_file(path, context)
+            file_context = context.copy()
+            lang = self._language_for_path(path)
+            if lang:
+                file_context["cross_file_analyzer"] = call_graphs.get(lang)
+            file_findings = await self._analyze_file(path, file_context)
             findings.extend(file_findings)
         return findings
 
@@ -189,6 +209,63 @@ class JSBehavioralCodeAnalyzer(BaseAnalyzer):
                 continue
             out.append(str(path))
         return sorted(out)
+
+    @staticmethod
+    def _language_for_path(file_path: str) -> Optional[str]:
+        """Map a source path to its tree-sitter language id."""
+        return _EXT_TO_TS_LANGUAGE.get(Path(file_path).suffix.lower())
+
+    def _build_directory_call_graphs(
+        self, files: List[str]
+    ) -> Dict[str, TreeSitterCallGraphAnalyzer]:
+        """Build per-language cross-file call graphs for a directory scan.
+
+        ``NativeAnalyzer`` needs these to resolve imported endpoint tables
+        (``tool.alias`` loops backed by ``api.endpoints`` in sibling modules).
+        """
+        analyzers: Dict[str, TreeSitterCallGraphAnalyzer] = {}
+        for path in files:
+            lang = self._language_for_path(path)
+            if not lang:
+                continue
+            try:
+                file_size = os.path.getsize(path)
+                if file_size > MCPScannerConstants.MAX_FILE_SIZE_BYTES * 5:
+                    self.logger.error(
+                        "js behavioural skip call_graph file=%s size=%d -- too large",
+                        path,
+                        file_size,
+                    )
+                    continue
+                with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                    source_code = fh.read()
+            except OSError as e:
+                self.logger.warning(
+                    "js behavioural call_graph read_failed file=%s error=%s",
+                    path,
+                    e,
+                )
+                continue
+
+            if lang not in analyzers:
+                analyzers[lang] = TreeSitterCallGraphAnalyzer(lang)
+            analyzers[lang].add_file(Path(path), source_code)
+
+        for lang, analyzer in analyzers.items():
+            try:
+                call_graph = analyzer.build_call_graph()
+                self.logger.debug(
+                    "js behavioural call_graph_built language=%s functions=%d",
+                    lang,
+                    len(call_graph.functions),
+                )
+            except Exception as e:  # noqa: BLE001
+                self.logger.warning(
+                    "js behavioural call_graph_build_failed language=%s error=%s",
+                    lang,
+                    e,
+                )
+        return analyzers
 
     # ------------------------------------------------------------------
     # Per-source orchestrator call

--- a/mcpscanner/core/analyzers/behavioral/js_code_analyzer.py
+++ b/mcpscanner/core/analyzers/behavioral/js_code_analyzer.py
@@ -180,11 +180,10 @@ class JSBehavioralCodeAnalyzer(BaseAnalyzer):
                 )
                 return []
             if file_path in self._source_cache:
-                source_code = self._source_cache[file_path]
+                source_code = self._source_cache.pop(file_path)
             else:
                 with open(file_path, "r", encoding="utf-8", errors="replace") as fh:
                     source_code = fh.read()
-                self._source_cache[file_path] = source_code
         except OSError as e:
             self.analysis_errors += 1
             self.logger.warning(

--- a/mcpscanner/core/analyzers/behavioral/js_code_analyzer.py
+++ b/mcpscanner/core/analyzers/behavioral/js_code_analyzer.py
@@ -59,6 +59,10 @@ _SKIP_DIRS = frozenset(
     {"node_modules", "dist", "build", "out", ".git", ".next", ".turbo", "coverage"}
 )
 
+# Aggregate budgets for directory-wide JS/TS call-graph construction.
+_JS_CALL_GRAPH_MAX_FILES = 200
+_JS_CALL_GRAPH_MAX_TOTAL_BYTES = MCPScannerConstants.MAX_FILE_SIZE_BYTES * 50
+
 # Keep in sync with ``BehavioralCodeAnalyzer._EXT_TO_TS_LANGUAGE`` for JS/TS.
 _EXT_TO_TS_LANGUAGE = {
     ".js": "javascript",
@@ -94,6 +98,8 @@ class JSBehavioralCodeAnalyzer(BaseAnalyzer):
         # ``analysis_scan_status`` reads it to downgrade such scans to
         # ``error`` instead of reporting ``is_safe=True``.
         self.analysis_errors = 0
+        self._source_cache: Dict[str, str] = {}
+        self._call_graph_partial = False
         self.logger.debug(
             "JSBehavioralCodeAnalyzer initialised with alignment orchestrator"
         )
@@ -114,6 +120,8 @@ class JSBehavioralCodeAnalyzer(BaseAnalyzer):
             confirms.
         """
         self.analysis_errors = 0
+        self._source_cache = {}
+        self._call_graph_partial = False
         try:
             if os.path.isdir(content):
                 return await self._analyze_directory(content, context)
@@ -143,6 +151,9 @@ class JSBehavioralCodeAnalyzer(BaseAnalyzer):
             "js behavioural scan root=%s files=%d", directory, len(files)
         )
         call_graphs = self._build_directory_call_graphs(files)
+        if self._call_graph_partial:
+            context = context.copy()
+            context["call_graph_partial"] = True
         findings: List[SecurityFinding] = []
         for path in files:
             file_context = context.copy()
@@ -168,8 +179,12 @@ class JSBehavioralCodeAnalyzer(BaseAnalyzer):
                     file_size,
                 )
                 return []
-            with open(file_path, "r", encoding="utf-8", errors="replace") as fh:
-                source_code = fh.read()
+            if file_path in self._source_cache:
+                source_code = self._source_cache[file_path]
+            else:
+                with open(file_path, "r", encoding="utf-8", errors="replace") as fh:
+                    source_code = fh.read()
+                self._source_cache[file_path] = source_code
         except OSError as e:
             self.analysis_errors += 1
             self.logger.warning(
@@ -222,9 +237,21 @@ class JSBehavioralCodeAnalyzer(BaseAnalyzer):
 
         ``NativeAnalyzer`` needs these to resolve imported endpoint tables
         (``tool.alias`` loops backed by ``api.endpoints`` in sibling modules).
+        Enforces aggregate file and byte budgets so untrusted packages cannot
+        exhaust memory before behavioural analysis begins.
         """
         analyzers: Dict[str, TreeSitterCallGraphAnalyzer] = {}
+        files_added = 0
+        total_bytes = 0
         for path in files:
+            if files_added >= _JS_CALL_GRAPH_MAX_FILES:
+                self._call_graph_partial = True
+                self.logger.warning(
+                    "js behavioural call_graph budget_exceeded files=%d limit=%d",
+                    files_added,
+                    _JS_CALL_GRAPH_MAX_FILES,
+                )
+                break
             lang = self._language_for_path(path)
             if not lang:
                 continue
@@ -237,8 +264,20 @@ class JSBehavioralCodeAnalyzer(BaseAnalyzer):
                         file_size,
                     )
                     continue
-                with open(path, "r", encoding="utf-8", errors="replace") as fh:
-                    source_code = fh.read()
+                if total_bytes + file_size > _JS_CALL_GRAPH_MAX_TOTAL_BYTES:
+                    self._call_graph_partial = True
+                    self.logger.warning(
+                        "js behavioural call_graph byte_budget_exceeded bytes=%d limit=%d",
+                        total_bytes,
+                        _JS_CALL_GRAPH_MAX_TOTAL_BYTES,
+                    )
+                    break
+                if path in self._source_cache:
+                    source_code = self._source_cache[path]
+                else:
+                    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                        source_code = fh.read()
+                    self._source_cache[path] = source_code
             except OSError as e:
                 self.logger.warning(
                     "js behavioural call_graph read_failed file=%s error=%s",
@@ -250,6 +289,8 @@ class JSBehavioralCodeAnalyzer(BaseAnalyzer):
             if lang not in analyzers:
                 analyzers[lang] = TreeSitterCallGraphAnalyzer(lang)
             analyzers[lang].add_file(Path(path), source_code)
+            files_added += 1
+            total_bytes += file_size
 
         for lang, analyzer in analyzers.items():
             try:

--- a/mcpscanner/core/static_analysis/native_analyzer.py
+++ b/mcpscanner/core/static_analysis/native_analyzer.py
@@ -1041,12 +1041,11 @@ class NativeAnalyzer:
         # resolved before call-site registrations so loop-variable member
         # accesses like ``tool.alias`` / ``m.name`` do not duplicate or
         # shadow the expanded literal tool names.
-        table_names = self._ts_collect_static_endpoint_tool_names(
+        table_names, table_loop_ranges = self._ts_collect_static_endpoint_tool_names(
             tree.root_node,
             import_target_map=import_target_map,
             cross_file_analyzer=cross_file_analyzer,
         )
-        table_name_set = set(table_names)
 
         wrapper_functions = self._ts_collect_tool_wrapper_functions(
             tree.root_node, mcp_instances
@@ -1054,7 +1053,7 @@ class NativeAnalyzer:
         registrations = self._ts_find_mcp_registrations(
             tree.root_node,
             trusted_receivers=mcp_instances,
-            wrapper_functions=wrapper_functions,
+            wrapper_functions=set(wrapper_functions),
         )
         registrations.extend(
             self._ts_find_wrapper_tool_registrations(
@@ -1063,17 +1062,21 @@ class NativeAnalyzer:
         )
 
         for reg in registrations:
-            reg_name = reg.get("name") or ""
-            handler_name = reg.get("handler_name") or ""
-            dynamic_name = reg_name or handler_name
-            if dynamic_name and "." in dynamic_name and table_name_set:
-                continue
-            if (
-                table_name_set
-                and reg.get("handler_node") is not None
-                and not reg_name
-            ):
-                continue
+            call_node = reg.get("call_node")
+            in_table_loop = self._ts_node_in_table_loop_scope(
+                call_node, table_loop_ranges
+            )
+            if in_table_loop:
+                reg_name = reg.get("name") or ""
+                handler_name = reg.get("handler_name") or ""
+                dynamic_name = reg_name or handler_name
+                if dynamic_name and "." in dynamic_name:
+                    continue
+                if (
+                    reg.get("handler_node") is not None
+                    and not reg_name
+                ):
+                    continue
             handler_node = reg.get("handler_node")
             handler_name = reg.get("handler_name")
             handler_origin: str = "inline"
@@ -2504,6 +2507,7 @@ class NativeAnalyzer:
                         reg.get("handler_node") is not None
                         or reg.get("handler_name") is not None
                     ):
+                        reg["call_node"] = node
                         registrations.append(reg)
             for child in node.children:
                 visit(child, node)
@@ -3173,33 +3177,28 @@ class NativeAnalyzer:
             "arrow_function",
             "function_expression",
         }
-        param_types = {
-            "parameter",
-            "formal_parameter",
-            "typed_parameter",
-            "function_parameter",
-            "value_parameter",
-            "required_parameter",
-            "optional_parameter",
-        }
         cur = node.parent
         while cur is not None:
             if cur.type in func_types:
                 names: Set[str] = set()
-                for child in cur.children:
-                    if child.type == "formal_parameters":
-                        for param in child.children:
-                            if param.type in param_types:
-                                pname = param.child_by_field_name("name")
-                                if pname is not None:
-                                    names.add(self._ts_get_node_text(pname))
-                    elif child.type in param_types:
-                        pname = child.child_by_field_name("name")
-                        if pname is not None:
-                            names.add(self._ts_get_node_text(pname))
+                for param in self._ts_extract_parameters(cur):
+                    pname = param.get("name")
+                    if pname:
+                        names.add(pname)
                 return names
             cur = cur.parent
         return set()
+
+    def _ts_node_in_table_loop_scope(
+        self,
+        node: Optional["Node"],
+        table_loop_ranges: List[tuple[int, int]],
+    ) -> bool:
+        """Return True when ``node`` sits inside a table-expanding loop."""
+        if node is None or not table_loop_ranges:
+            return False
+        pos = node.start_byte
+        return any(start <= pos < end for start, end in table_loop_ranges)
 
     def _ts_is_inside_named_function(
         self, node: "Node", function_names: Set[str]
@@ -3221,19 +3220,19 @@ class NativeAnalyzer:
 
     def _ts_collect_tool_wrapper_functions(
         self, root: "Node", trusted_receivers: Set[str]
-    ) -> Set[str]:
-        """Functions whose body delegates to ``server.tool(...)`` etc."""
-        wrappers: Set[str] = set()
-        func_types = self.FUNCTION_NODE_TYPES.get(self.language, set()) | {
-            "function_declaration",
-        }
+    ) -> Dict[str, str]:
+        """Functions whose body delegates to ``server.tool(...)`` etc.
 
-        def body_returns_tool_registration(fn_node: "Node") -> bool:
-            found = False
+        Returns ``{wrapper_name: capability_kind}``.
+        """
+        wrappers: Dict[str, str] = {}
+
+        def body_returns_mcp_registration(fn_node: "Node") -> Optional[str]:
+            found_cap: Optional[str] = None
 
             def walk(node: "Node") -> None:
-                nonlocal found
-                if found:
+                nonlocal found_cap
+                if found_cap:
                     return
                 if node.type == "return_statement":
                     for child in node.children:
@@ -3245,22 +3244,20 @@ class NativeAnalyzer:
                             if self._ts_receiver_is_trusted(
                                 child, method_lc, trusted_receivers
                             ):
-                                found = True
+                                found_cap = _normalize_capability(method_lc)
                                 return
                 for child in node.children:
                     walk(child)
 
             walk(fn_node)
-            return found
+            return found_cap
 
         def visit(node: "Node") -> None:
             if node.type == "function_declaration":
                 name_node = node.child_by_field_name("name")
-                if (
-                    name_node is not None
-                    and body_returns_tool_registration(node)
-                ):
-                    wrappers.add(self._ts_get_node_text(name_node))
+                cap_kind = body_returns_mcp_registration(node)
+                if name_node is not None and cap_kind is not None:
+                    wrappers[self._ts_get_node_text(name_node)] = cap_kind
             for child in node.children:
                 visit(child)
 
@@ -3268,7 +3265,7 @@ class NativeAnalyzer:
         return wrappers
 
     def _ts_find_wrapper_tool_registrations(
-        self, root: "Node", wrapper_functions: Set[str]
+        self, root: "Node", wrapper_functions: Dict[str, str]
     ) -> List[Dict[str, Any]]:
         """Registrations made via custom wrappers like ``safeTool('x', ...)``."""
         if not wrapper_functions:
@@ -3280,12 +3277,14 @@ class NativeAnalyzer:
         def visit(node: "Node") -> None:
             if node.type == "call_expression":
                 callee = self._ts_call_callee_identifier(node)
-                if callee in wrapper_functions:
+                cap_kind = wrapper_functions.get(callee) if callee else None
+                if cap_kind is not None:
                     args_node = self._ts_call_arguments_node(node)
                     reg = self._ts_parse_wrapper_registration_args(
-                        args_node, func_types
+                        args_node, func_types, capability=cap_kind
                     )
                     if reg is not None:
+                        reg["call_node"] = node
                         registrations.append(reg)
             for child in node.children:
                 visit(child)
@@ -3309,6 +3308,8 @@ class NativeAnalyzer:
         self,
         args_node: Optional["Node"],
         func_types: Set[str],
+        *,
+        capability: str = "tool",
     ) -> Optional[Dict[str, Any]]:
         """Parse ``wrapper('tool-name', schema, handler)`` call sites."""
         if args_node is None:
@@ -3351,7 +3352,7 @@ class NativeAnalyzer:
             return None
 
         return {
-            "capability": "tool",
+            "capability": capability,
             "name": name,
             "handler_node": inline_handler,
             "handler_name": handler_name,
@@ -3381,22 +3382,30 @@ class NativeAnalyzer:
         *,
         import_target_map: Optional[Dict[str, List[str]]] = None,
         cross_file_analyzer: Optional[Any] = None,
-    ) -> List[str]:
+    ) -> tuple[List[str], List[tuple[int, int]]]:
         """Collect static MCP tool names from descriptor arrays.
 
         Only arrays reached through ``for (const tool of api.endpoints)``-style
         loops are considered (in-file and cross-file). A blanket walk of every
         array literal would mis-tag HTTP route tables and model catalogues as
         MCP tools.
+
+        Returns ``(tool_names, loop_byte_ranges)`` where each range covers a
+        ``for...of`` / ``forEach`` site that expanded a static table.
         """
         names: List[str] = []
         seen: Set[str] = set()
+        table_loop_ranges: List[tuple[int, int]] = []
         bindings = self._ts_build_simple_value_bindings(root)
 
         def add_name(value: Optional[str]) -> None:
             if value and value not in seen:
                 seen.add(value)
                 names.append(value)
+
+        def record_loop_scope(loop_node: "Node", expanded: List[str]) -> None:
+            if expanded:
+                table_loop_ranges.append((loop_node.start_byte, loop_node.end_byte))
 
         def visit(node: "Node") -> None:
             if node.type in ("for_in_statement", "for_of_statement"):
@@ -3410,21 +3419,23 @@ class NativeAnalyzer:
                             cross_file_analyzer=cross_file_analyzer,
                         )
                     if array_node is not None:
-                        for tool_name in self._ts_endpoint_names_in_array(array_node):
+                        expanded = self._ts_endpoint_names_in_array(array_node)
+                        for tool_name in expanded:
                             add_name(tool_name)
+                        record_loop_scope(node, expanded)
             if node.type == "call_expression":
                 if self._ts_call_method_name(node) == "forEach":
                     array_node = self._ts_forEach_source_array(node, bindings, root)
                     if array_node is not None:
-                        for tool_name in self._ts_endpoint_names_in_array(
-                            array_node
-                        ):
+                        expanded = self._ts_endpoint_names_in_array(array_node)
+                        for tool_name in expanded:
                             add_name(tool_name)
+                        record_loop_scope(node, expanded)
             for child in node.children:
                 visit(child)
 
         visit(root)
-        return names
+        return names, table_loop_ranges
 
     def _ts_endpoint_names_in_array(self, array_node: "Node") -> List[str]:
         """Return string tool names from object elements in an array literal."""

--- a/mcpscanner/core/static_analysis/native_analyzer.py
+++ b/mcpscanner/core/static_analysis/native_analyzer.py
@@ -1112,7 +1112,7 @@ class NativeAnalyzer:
             # ``<registration>.unresolved.<kind>`` so consumers can
             # distinguish them from analyzed handlers.
             if handler_node is None and cross_file_match is None:
-                if not (handler_name or reg.get("name")):
+                if not (handler_name or self._ts_registration_display_name(reg)):
                     continue
                 template_subtype = reg.get("template_subtype")
                 source_kind = (
@@ -1130,7 +1130,7 @@ class NativeAnalyzer:
                 self._append_unresolved_capability(
                     contexts,
                     capability=cap_kind,
-                    registered_name=reg.get("name") or handler_name,
+                    registered_name=self._ts_registration_display_name(reg),
                     source_kind=source_kind,
                     handler_name_hint=handler_name,
                 )
@@ -1156,7 +1156,7 @@ class NativeAnalyzer:
                 self._append_unresolved_capability(
                     contexts,
                     capability=cap_kind,
-                    registered_name=reg.get("name") or handler_name,
+                    registered_name=self._ts_registration_display_name(reg),
                     source_kind=source_kind,
                     handler_name_hint=handler_name,
                     source_file=cross_file_path,
@@ -1182,7 +1182,7 @@ class NativeAnalyzer:
                 handler_node,
                 imports,
                 capability=cap_kind,
-                registered_name=reg.get("name"),
+                registered_name=self._ts_registration_display_name(reg),
                 source_kind=source_kind,
             )
 
@@ -3138,15 +3138,24 @@ class NativeAnalyzer:
             if candidate not in param_names and "." not in candidate:
                 name = candidate
 
+        name_ref: Optional[str] = None
+        if name is None and refs and "." in refs[0]:
+            name_ref = refs[0]
+
         if handler_node is None and handler_name is None:
             return None
 
         return {
             "capability": override_capability or _normalize_capability(capability_method),
             "name": name,
+            "name_ref": name_ref,
             "handler_node": handler_node,
             "handler_name": handler_name,
         }
+
+    def _ts_registration_display_name(self, reg: Dict[str, Any]) -> Optional[str]:
+        """Prefer literal MCP name, then member-expression ref, then handler."""
+        return reg.get("name") or reg.get("name_ref") or reg.get("handler_name")
 
     def _ts_parse_bind_handler_name(self, call_node: "Node") -> Optional[str]:
         """Return a method name from ``this.method.bind(...)`` call expressions."""

--- a/mcpscanner/core/static_analysis/native_analyzer.py
+++ b/mcpscanner/core/static_analysis/native_analyzer.py
@@ -1029,10 +1029,6 @@ class NativeAnalyzer:
         # from false-positive-classifying as MCP registrations.
         mcp_instances = self._collect_mcp_instances(tree.root_node, imports)
 
-        registrations = self._ts_find_mcp_registrations(
-            tree.root_node, trusted_receivers=mcp_instances
-        )
-
         # Build an import-target map once per extract call: cross-file
         # resolution prefers entries whose defining file path matches
         # one of the calling file's import targets, killing the
@@ -1041,7 +1037,43 @@ class NativeAnalyzer:
             imports, current_file=str(self.file_path) if self.file_path else None
         )
 
+        # Static endpoint tables (``for...of`` / ``forEach`` loops) are
+        # resolved before call-site registrations so loop-variable member
+        # accesses like ``tool.alias`` / ``m.name`` do not duplicate or
+        # shadow the expanded literal tool names.
+        table_names = self._ts_collect_static_endpoint_tool_names(
+            tree.root_node,
+            import_target_map=import_target_map,
+            cross_file_analyzer=cross_file_analyzer,
+        )
+        table_name_set = set(table_names)
+
+        wrapper_functions = self._ts_collect_tool_wrapper_functions(
+            tree.root_node, mcp_instances
+        )
+        registrations = self._ts_find_mcp_registrations(
+            tree.root_node,
+            trusted_receivers=mcp_instances,
+            wrapper_functions=wrapper_functions,
+        )
+        registrations.extend(
+            self._ts_find_wrapper_tool_registrations(
+                tree.root_node, wrapper_functions
+            )
+        )
+
         for reg in registrations:
+            reg_name = reg.get("name") or ""
+            handler_name = reg.get("handler_name") or ""
+            dynamic_name = reg_name or handler_name
+            if dynamic_name and "." in dynamic_name and table_name_set:
+                continue
+            if (
+                table_name_set
+                and reg.get("handler_node") is not None
+                and not reg_name
+            ):
+                continue
             handler_node = reg.get("handler_node")
             handler_name = reg.get("handler_name")
             handler_origin: str = "inline"
@@ -1151,14 +1183,6 @@ class NativeAnalyzer:
                 source_kind=source_kind,
             )
 
-        # Gap 8 extension: static endpoint tables (literal ``name`` /
-        # ``alias`` fields) including arrays reached via ``for (const tool
-        # of api.endpoints)`` loops (in-file and cross-file).
-        table_names = self._ts_collect_static_endpoint_tool_names(
-            tree.root_node,
-            import_target_map=import_target_map,
-            cross_file_analyzer=cross_file_analyzer,
-        )
         for tool_name in table_names:
             cap_key = (f"table:{tool_name}", "tool")
             if cap_key in seen_handlers:
@@ -2336,6 +2360,7 @@ class NativeAnalyzer:
         self,
         root: "Node",
         trusted_receivers: Optional[Set[str]] = None,
+        wrapper_functions: Optional[Set[str]] = None,
     ) -> List[Dict[str, Any]]:
         """Find call expressions that look like MCP capability registrations.
 
@@ -2368,6 +2393,7 @@ class NativeAnalyzer:
         """
         registrations: List[Dict[str, Any]] = []
         trusted_receivers = trusted_receivers or set()
+        wrapper_functions = wrapper_functions or set()
 
         def visit(node: "Node", parent: Optional["Node"]):
             if node.type == "call_expression":
@@ -2380,6 +2406,12 @@ class NativeAnalyzer:
                 )
 
                 if is_registration_method:
+                    if wrapper_functions and self._ts_is_inside_named_function(
+                        node, wrapper_functions
+                    ):
+                        for child in node.children:
+                            visit(child, node)
+                        return
                     # Receiver verification: drop unrelated DSLs that
                     # happen to expose ``.tool(...)`` etc.
                     if not self._ts_receiver_is_trusted(
@@ -2401,7 +2433,7 @@ class NativeAnalyzer:
                                 visit(child, node)
                             return
                         reg = self._ts_parse_registration_args(
-                            args_node, method_lc, override_capability=ll_cap
+                            args_node, method_lc, override_capability=ll_cap, call_node=node
                         )
                         if reg is None:
                             reg = {
@@ -2412,7 +2444,9 @@ class NativeAnalyzer:
                             }
                         reg["template_subtype"] = None
                     else:
-                        reg = self._ts_parse_registration_args(args_node, method_lc)
+                        reg = self._ts_parse_registration_args(
+                            args_node, method_lc, call_node=node
+                        )
                         if reg is None:
                             reg = {
                                 "capability": _normalize_capability(method_lc),
@@ -2510,7 +2544,13 @@ class NativeAnalyzer:
             # trusted because they can only have come from a direct
             # import of the SDK function.
             return True
-        return receiver in trusted_receivers
+        if receiver in trusted_receivers:
+            return True
+        # ``this.server.tool(...)`` when ``server`` is a trusted field.
+        for part in receiver.split("."):
+            if part in trusted_receivers:
+                return True
+        return False
 
     def _ts_call_receiver_name(self, call_node: "Node") -> Optional[str]:
         """Return the receiver expression of a ``X.method(...)`` call.
@@ -2545,7 +2585,7 @@ class NativeAnalyzer:
         for field in ("object", "operand", "expression"):
             recv = func.child_by_field_name(field)
             if recv is not None:
-                return self._ts_get_node_text(recv).strip().split(".")[0]
+                return self._ts_get_node_text(recv).strip()
         for child in func.children:
             if child.is_named:
                 return self._ts_get_node_text(child).strip().split(".")[0]
@@ -2664,6 +2704,17 @@ class NativeAnalyzer:
                     if self._ts_is_mcp_instantiation(value_node, sdk_classes):
                         trusted.add(self._ts_get_node_text(name_node))
 
+            if node.type in (
+                "public_field_definition",
+                "field_definition",
+                "property_declaration",
+            ):
+                name_node = node.child_by_field_name("name")
+                value_node = node.child_by_field_name("value")
+                if name_node is not None and value_node is not None:
+                    if self._ts_is_mcp_instantiation(value_node, sdk_classes):
+                        trusted.add(self._ts_get_node_text(name_node))
+
             # Go: ``server := mcp.NewServer(...)`` parses as
             # ``short_var_declaration`` with ``left`` (identifier) and
             # ``right`` (call_expression).
@@ -2683,11 +2734,25 @@ class NativeAnalyzer:
                 "typed_parameter",
                 "function_parameter",
                 "value_parameter",
+                "required_parameter",
+                "optional_parameter",
             ):
                 pname = node.child_by_field_name("name")
+                if pname is None:
+                    for child in node.children:
+                        if child.type == "identifier":
+                            pname = child
+                            break
                 ptype = node.child_by_field_name("type")
+                if ptype is None:
+                    for child in node.children:
+                        if child.type == "type_annotation":
+                            ptype = child
+                            break
                 if pname is not None and ptype is not None:
                     type_text = self._ts_get_node_text(ptype).strip()
+                    if type_text.startswith(":"):
+                        type_text = type_text[1:].strip()
                     if (
                         type_text in sdk_classes
                         or type_text.split(".")[-1] in sdk_classes
@@ -2939,6 +3004,8 @@ class NativeAnalyzer:
         args_node: Optional["Node"],
         capability_method: str,
         override_capability: Optional[str] = None,
+        *,
+        call_node: Optional["Node"] = None,
     ) -> Optional[Dict[str, Any]]:
         """Pull the registered name + handler out of a registration call.
 
@@ -2992,6 +3059,12 @@ class NativeAnalyzer:
                 positional.append(("ref", self._ts_get_node_text(child)))
                 continue
 
+            if child.type == "call_expression":
+                bind_method = self._ts_parse_bind_handler_name(child)
+                if bind_method:
+                    positional.append(("bind_ref", bind_method))
+                    continue
+
             if child.type in string_node_types:
                 positional.append(
                     ("string", _strip_string_quotes(self._ts_get_node_text(child)))
@@ -3036,11 +3109,14 @@ class NativeAnalyzer:
 
         inline_handlers = [val for kind, val in positional if kind == "inline"]
         refs = [val for kind, val in positional if kind == "ref"]
+        bind_refs = [val for kind, val in positional if kind == "bind_ref"]
 
         handler_node = inline_handlers[-1] if inline_handlers else None
         handler_name: Optional[str] = None
 
-        if handler_node is None and refs:
+        if handler_node is None and bind_refs:
+            handler_name = bind_refs[-1]
+        elif handler_node is None and refs:
             handler_name = refs[-1]
 
         if (
@@ -3049,7 +3125,14 @@ class NativeAnalyzer:
             and self.language in ("javascript", "typescript")
             and capability_method.lower() not in _MCP_LOW_LEVEL_REGISTRATION_METHODS
         ):
-            name = refs[0]
+            candidate = refs[0]
+            param_names = (
+                self._ts_enclosing_function_param_names(call_node)
+                if call_node is not None
+                else set()
+            )
+            if candidate not in param_names and "." not in candidate:
+                name = candidate
 
         if handler_node is None and handler_name is None:
             return None
@@ -3058,6 +3141,219 @@ class NativeAnalyzer:
             "capability": override_capability or _normalize_capability(capability_method),
             "name": name,
             "handler_node": handler_node,
+            "handler_name": handler_name,
+        }
+
+    def _ts_parse_bind_handler_name(self, call_node: "Node") -> Optional[str]:
+        """Return a method name from ``this.method.bind(...)`` call expressions."""
+        if call_node.type != "call_expression":
+            return None
+        func = call_node.child_by_field_name("function")
+        if func is None or func.type not in _TS_MEMBER_EXPR_TYPES:
+            return None
+        bind_prop = func.child_by_field_name("property")
+        if bind_prop is None or self._ts_get_node_text(bind_prop) != "bind":
+            return None
+        target = func.child_by_field_name("object")
+        if target is None:
+            return None
+        if target.type in _TS_MEMBER_EXPR_TYPES:
+            method_prop = target.child_by_field_name("property")
+            if method_prop is not None:
+                return self._ts_get_node_text(method_prop)
+        if target.type == "identifier":
+            return self._ts_get_node_text(target)
+        return None
+
+    def _ts_enclosing_function_param_names(self, node: "Node") -> Set[str]:
+        """Parameter names declared on the nearest enclosing function."""
+        func_types = self.FUNCTION_NODE_TYPES.get(self.language, set()) | {
+            "function_declaration",
+            "method_definition",
+            "arrow_function",
+            "function_expression",
+        }
+        param_types = {
+            "parameter",
+            "formal_parameter",
+            "typed_parameter",
+            "function_parameter",
+            "value_parameter",
+            "required_parameter",
+            "optional_parameter",
+        }
+        cur = node.parent
+        while cur is not None:
+            if cur.type in func_types:
+                names: Set[str] = set()
+                for child in cur.children:
+                    if child.type == "formal_parameters":
+                        for param in child.children:
+                            if param.type in param_types:
+                                pname = param.child_by_field_name("name")
+                                if pname is not None:
+                                    names.add(self._ts_get_node_text(pname))
+                    elif child.type in param_types:
+                        pname = child.child_by_field_name("name")
+                        if pname is not None:
+                            names.add(self._ts_get_node_text(pname))
+                return names
+            cur = cur.parent
+        return set()
+
+    def _ts_is_inside_named_function(
+        self, node: "Node", function_names: Set[str]
+    ) -> bool:
+        """Return True when ``node`` sits inside one of ``function_names``."""
+        func_types = self.FUNCTION_NODE_TYPES.get(self.language, set()) | {
+            "function_declaration",
+            "method_definition",
+        }
+        cur = node.parent
+        while cur is not None:
+            if cur.type in func_types:
+                name_node = cur.child_by_field_name("name")
+                if name_node is not None:
+                    return self._ts_get_node_text(name_node) in function_names
+                return False
+            cur = cur.parent
+        return False
+
+    def _ts_collect_tool_wrapper_functions(
+        self, root: "Node", trusted_receivers: Set[str]
+    ) -> Set[str]:
+        """Functions whose body delegates to ``server.tool(...)`` etc."""
+        wrappers: Set[str] = set()
+        func_types = self.FUNCTION_NODE_TYPES.get(self.language, set()) | {
+            "function_declaration",
+        }
+
+        def body_returns_tool_registration(fn_node: "Node") -> bool:
+            found = False
+
+            def walk(node: "Node") -> None:
+                nonlocal found
+                if found:
+                    return
+                if node.type == "return_statement":
+                    for child in node.children:
+                        if child.type != "call_expression":
+                            continue
+                        method = self._ts_call_method_name(child)
+                        method_lc = method.lower() if method else ""
+                        if method_lc in _MCP_REGISTRATION_METHODS:
+                            if self._ts_receiver_is_trusted(
+                                child, method_lc, trusted_receivers
+                            ):
+                                found = True
+                                return
+                for child in node.children:
+                    walk(child)
+
+            walk(fn_node)
+            return found
+
+        def visit(node: "Node") -> None:
+            if node.type == "function_declaration":
+                name_node = node.child_by_field_name("name")
+                if (
+                    name_node is not None
+                    and body_returns_tool_registration(node)
+                ):
+                    wrappers.add(self._ts_get_node_text(name_node))
+            for child in node.children:
+                visit(child)
+
+        visit(root)
+        return wrappers
+
+    def _ts_find_wrapper_tool_registrations(
+        self, root: "Node", wrapper_functions: Set[str]
+    ) -> List[Dict[str, Any]]:
+        """Registrations made via custom wrappers like ``safeTool('x', ...)``."""
+        if not wrapper_functions:
+            return []
+
+        func_types = self.FUNCTION_NODE_TYPES.get(self.language, set())
+        registrations: List[Dict[str, Any]] = []
+
+        def visit(node: "Node") -> None:
+            if node.type == "call_expression":
+                callee = self._ts_call_callee_identifier(node)
+                if callee in wrapper_functions:
+                    args_node = self._ts_call_arguments_node(node)
+                    reg = self._ts_parse_wrapper_registration_args(
+                        args_node, func_types
+                    )
+                    if reg is not None:
+                        registrations.append(reg)
+            for child in node.children:
+                visit(child)
+
+        visit(root)
+        return registrations
+
+    def _ts_call_callee_identifier(self, call_node: "Node") -> Optional[str]:
+        """Return the bare identifier for ``fn(...)`` calls."""
+        func = call_node.child_by_field_name("function")
+        if func is None:
+            for child in call_node.children:
+                if child.type == "identifier":
+                    return self._ts_get_node_text(child)
+            return None
+        if func.type == "identifier":
+            return self._ts_get_node_text(func)
+        return None
+
+    def _ts_parse_wrapper_registration_args(
+        self,
+        args_node: Optional["Node"],
+        func_types: Set[str],
+    ) -> Optional[Dict[str, Any]]:
+        """Parse ``wrapper('tool-name', schema, handler)`` call sites."""
+        if args_node is None:
+            return None
+
+        string_node_types = {
+            "string",
+            "string_literal",
+            "template_string",
+            "raw_string_literal",
+            "interpreted_string_literal",
+        }
+        name: Optional[str] = None
+        inline_handler: Optional["Node"] = None
+        handler_name: Optional[str] = None
+        refs: List[str] = []
+
+        for child in args_node.children:
+            if child.type in ("(", ")", ",", "comment"):
+                continue
+            if child.type in string_node_types:
+                if name is None:
+                    name = _strip_string_quotes(self._ts_get_node_text(child))
+                continue
+            if child.type in func_types:
+                inline_handler = child
+                continue
+            if child.type == "identifier":
+                refs.append(self._ts_get_node_text(child))
+                continue
+            if child.type in _TS_MEMBER_EXPR_TYPES:
+                refs.append(self._ts_get_node_text(child))
+                continue
+            if child.type in ("object", "object_expression"):
+                continue
+
+        if inline_handler is None and refs:
+            handler_name = refs[-1]
+        if name is None or (inline_handler is None and handler_name is None):
+            return None
+
+        return {
+            "capability": "tool",
+            "name": name,
+            "handler_node": inline_handler,
             "handler_name": handler_name,
         }
 
@@ -3115,6 +3411,14 @@ class NativeAnalyzer:
                         )
                     if array_node is not None:
                         for tool_name in self._ts_endpoint_names_in_array(array_node):
+                            add_name(tool_name)
+            if node.type == "call_expression":
+                if self._ts_call_method_name(node) == "forEach":
+                    array_node = self._ts_forEach_source_array(node, bindings, root)
+                    if array_node is not None:
+                        for tool_name in self._ts_endpoint_names_in_array(
+                            array_node
+                        ):
                             add_name(tool_name)
             for child in node.children:
                 visit(child)
@@ -3197,6 +3501,24 @@ class NativeAnalyzer:
             if seen_of and child.type not in skip_types:
                 return child
         return None
+
+    def _ts_forEach_source_array(
+        self,
+        call_node: "Node",
+        bindings: Dict[str, "Node"],
+        root: "Node",
+    ) -> Optional["Node"]:
+        """Resolve ``tools.forEach(...)`` to its array literal node."""
+        func = call_node.child_by_field_name("function")
+        if func is None or func.type not in _TS_MEMBER_EXPR_TYPES:
+            return None
+        prop = func.child_by_field_name("property")
+        if prop is None or self._ts_get_node_text(prop) != "forEach":
+            return None
+        obj = func.child_by_field_name("object")
+        if obj is None:
+            return None
+        return self._ts_resolve_to_array_node(obj, bindings, root)
 
     def _ts_resolve_to_array_node(
         self,

--- a/mcpscanner/core/static_analysis/native_analyzer.py
+++ b/mcpscanner/core/static_analysis/native_analyzer.py
@@ -1041,10 +1041,11 @@ class NativeAnalyzer:
         # resolved before call-site registrations so loop-variable member
         # accesses like ``tool.alias`` / ``m.name`` do not duplicate or
         # shadow the expanded literal tool names.
-        table_names, table_loop_ranges = self._ts_collect_static_endpoint_tool_names(
+        table_names, table_loops = self._ts_collect_static_endpoint_tool_names(
             tree.root_node,
             import_target_map=import_target_map,
             cross_file_analyzer=cross_file_analyzer,
+            trusted_receivers=mcp_instances,
         )
 
         wrapper_functions = self._ts_collect_tool_wrapper_functions(
@@ -1061,30 +1062,65 @@ class NativeAnalyzer:
             )
         )
 
+        table_covered_names: Set[str] = set()
+
         for reg in registrations:
             call_node = reg.get("call_node")
-            in_table_loop = self._ts_node_in_table_loop_scope(
-                call_node, table_loop_ranges
-            )
-            if in_table_loop:
-                reg_name = reg.get("name") or ""
-                handler_name = reg.get("handler_name") or ""
-                dynamic_name = reg_name or handler_name
-                if dynamic_name and "." in dynamic_name:
-                    continue
-                if (
-                    reg.get("handler_node") is not None
-                    and not reg_name
-                ):
-                    continue
+            loop_info = self._ts_table_loop_for_node(call_node, table_loops)
+            in_table_loop = loop_info is not None
             handler_node = reg.get("handler_node")
             handler_name = reg.get("handler_name")
+            reg_name = reg.get("name") or ""
+
+            # Table loops with a shared inline handler: clone the handler
+            # context for every statically expanded tool name instead of
+            # dropping executable evidence and emitting name-only stubs.
+            if (
+                in_table_loop
+                and handler_node is not None
+                and not reg_name
+                and loop_info is not None
+            ):
+                cap_kind = reg["capability"]
+                template_subtype = reg.get("template_subtype")
+                source_kind = (
+                    "registration.template"
+                    if template_subtype == "template"
+                    else "registration"
+                )
+                for tool_name in loop_info.get("names", []):
+                    cap_key = (handler_node.start_byte, cap_kind, tool_name)
+                    if cap_key in seen_handlers:
+                        continue
+                    seen_handlers.add(cap_key)
+                    table_covered_names.add(tool_name)
+                    self._append_capability_context(
+                        contexts,
+                        handler_node,
+                        imports,
+                        capability=cap_kind,
+                        registered_name=tool_name,
+                        source_kind=source_kind,
+                    )
+                continue
+
+            if in_table_loop:
+                dynamic_name = reg_name or (handler_name or "")
+                if dynamic_name and "." in dynamic_name:
+                    continue
             handler_origin: str = "inline"
 
             if handler_node is None and handler_name:
-                handler_node = self._ts_find_function_def_by_name(
-                    tree.root_node, handler_name, func_types
+                handler_node = self._ts_resolve_handler_reference(
+                    tree.root_node,
+                    handler_name,
+                    call_node or tree.root_node,
+                    func_types,
                 )
+                if handler_node is None:
+                    handler_node = self._ts_find_function_def_by_name(
+                        tree.root_node, handler_name, func_types
+                    )
                 if handler_node is not None:
                     handler_origin = "in_file"
 
@@ -1187,6 +1223,8 @@ class NativeAnalyzer:
             )
 
         for tool_name in table_names:
+            if tool_name in table_covered_names:
+                continue
             cap_key = (f"table:{tool_name}", "tool")
             if cap_key in seen_handlers:
                 continue
@@ -2550,9 +2588,12 @@ class NativeAnalyzer:
             return True
         if receiver in trusted_receivers:
             return True
-        # ``this.server.tool(...)`` when ``server`` is a trusted field.
-        for part in receiver.split("."):
-            if part in trusted_receivers:
+        # ``this.server.tool(...)`` when ``server`` is a trusted field on
+        # the enclosing instance. Do not treat ``attacker.server`` as
+        # trusted just because ``server`` appears in the path.
+        if receiver.startswith("this."):
+            field = receiver.split(".", 1)[1]
+            if field in trusted_receivers:
                 return True
         return False
 
@@ -3171,12 +3212,38 @@ class NativeAnalyzer:
         if target is None:
             return None
         if target.type in _TS_MEMBER_EXPR_TYPES:
-            method_prop = target.child_by_field_name("property")
-            if method_prop is not None:
-                return self._ts_get_node_text(method_prop)
+            return self._ts_get_node_text(target)
         if target.type == "identifier":
             return self._ts_get_node_text(target)
         return None
+
+    def _ts_function_parameter_names(self, fn_node: "Node") -> Set[str]:
+        """Parameter names declared on a function/arrow node."""
+        names: Set[str] = set()
+        for param in self._ts_extract_parameters(fn_node):
+            pname = param.get("name")
+            if pname:
+                names.add(pname)
+        if fn_node.type == "arrow_function":
+            for child in fn_node.children:
+                if child.type == "identifier":
+                    names.add(self._ts_get_node_text(child))
+                    break
+                if child.type in ("formal_parameters", "parameters"):
+                    for sub in child.children:
+                        if sub.type == "identifier":
+                            names.add(self._ts_get_node_text(sub))
+                        elif sub.type in (
+                            "required_parameter",
+                            "optional_parameter",
+                        ):
+                            name_node = sub.child_by_field_name("pattern") or sub.child_by_field_name(
+                                "name"
+                            )
+                            if name_node is not None:
+                                names.add(self._ts_get_node_text(name_node))
+                    break
+        return names
 
     def _ts_enclosing_function_param_names(self, node: "Node") -> Set[str]:
         """Parameter names declared on the nearest enclosing function."""
@@ -3186,28 +3253,282 @@ class NativeAnalyzer:
             "arrow_function",
             "function_expression",
         }
-        cur = node.parent
+        cur = node
         while cur is not None:
             if cur.type in func_types:
-                names: Set[str] = set()
-                for param in self._ts_extract_parameters(cur):
-                    pname = param.get("name")
-                    if pname:
-                        names.add(pname)
-                return names
+                return self._ts_function_parameter_names(cur)
             cur = cur.parent
         return set()
 
-    def _ts_node_in_table_loop_scope(
+    def _ts_table_loop_for_node(
         self,
         node: Optional["Node"],
-        table_loop_ranges: List[tuple[int, int]],
-    ) -> bool:
-        """Return True when ``node`` sits inside a table-expanding loop."""
-        if node is None or not table_loop_ranges:
-            return False
+        table_loops: List[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        """Return the table-expanding loop metadata containing ``node``."""
+        if node is None or not table_loops:
+            return None
         pos = node.start_byte
-        return any(start <= pos < end for start, end in table_loop_ranges)
+        for loop_info in table_loops:
+            start = loop_info.get("start", -1)
+            end = loop_info.get("end", -1)
+            if start <= pos < end:
+                return loop_info
+        return None
+
+    def _ts_is_parameter_shadow(self, use_site: "Node", name: str) -> bool:
+        """Return True when ``name`` is a parameter of the enclosing function."""
+        func_types = self.FUNCTION_NODE_TYPES.get(self.language, set()) | {
+            "function_declaration",
+            "method_definition",
+            "arrow_function",
+            "function_expression",
+        }
+        cur = use_site.parent
+        while cur is not None:
+            if cur.type in func_types:
+                return name in self._ts_function_parameter_names(cur)
+            cur = cur.parent
+        return False
+
+    def _ts_forEach_callback_node(self, call_node: "Node") -> Optional["Node"]:
+        """Return the callback passed to ``array.forEach(...)``."""
+        args_node = self._ts_call_arguments_node(call_node)
+        if args_node is None:
+            return None
+        for child in args_node.children:
+            if child.type in ("(", ")", ","):
+                continue
+            return child
+        return None
+
+    def _ts_for_loop_iteration_names(self, for_node: "Node") -> Set[str]:
+        """Iteration binding names from a ``for...of`` loop header."""
+        names: Set[str] = set()
+        left = for_node.child_by_field_name("left")
+        if left is None:
+            seen_of = False
+            for child in for_node.children:
+                if child.type == "of":
+                    seen_of = True
+                    continue
+                if not seen_of:
+                    continue
+                if child.type in ("lexical_declaration", "variable_declaration"):
+                    for sub in child.children:
+                        if sub.type == "variable_declarator":
+                            name_node = sub.child_by_field_name("name")
+                            if name_node is not None:
+                                names.add(self._ts_get_node_text(name_node))
+                elif child.type == "identifier":
+                    names.add(self._ts_get_node_text(child))
+                break
+            return names
+
+        if left.type in ("lexical_declaration", "variable_declaration"):
+            for child in left.children:
+                if child.type == "variable_declarator":
+                    name_node = child.child_by_field_name("name")
+                    if name_node is not None:
+                        names.add(self._ts_get_node_text(name_node))
+        elif left.type == "identifier":
+            names.add(self._ts_get_node_text(left))
+        return names
+
+    def _ts_loop_iteration_names(self, loop_node: "Node") -> Set[str]:
+        """Iteration binding names for ``for...of`` or ``forEach`` loops."""
+        if loop_node.type in ("for_in_statement", "for_of_statement"):
+            return self._ts_for_loop_iteration_names(loop_node)
+        if loop_node.type == "call_expression":
+            callback = self._ts_forEach_callback_node(loop_node)
+            if callback is None:
+                return set()
+            if callback.type in (
+                "arrow_function",
+                "function_expression",
+                "function",
+            ):
+                return self._ts_function_parameter_names(callback)
+        return set()
+
+    def _ts_call_references_iteration_binding(
+        self, call_node: "Node", iteration_names: Set[str]
+    ) -> bool:
+        """Return True when registration args reference a loop iteration var."""
+        if not iteration_names:
+            return False
+        args_node = self._ts_call_arguments_node(call_node)
+        if args_node is None:
+            return False
+
+        def references(node: "Node") -> bool:
+            if node.type == "identifier":
+                return self._ts_get_node_text(node) in iteration_names
+            if node.type in _TS_MEMBER_EXPR_TYPES:
+                obj = node.child_by_field_name("object")
+                if (
+                    obj is not None
+                    and obj.type == "identifier"
+                    and self._ts_get_node_text(obj) in iteration_names
+                ):
+                    return True
+            for child in node.children:
+                if references(child):
+                    return True
+            return False
+
+        return references(args_node)
+
+    def _ts_loop_has_trusted_mcp_registration(
+        self,
+        loop_node: "Node",
+        trusted_receivers: Set[str],
+    ) -> bool:
+        """Return True when a loop body contains a trusted MCP registration."""
+        iteration_names = self._ts_loop_iteration_names(loop_node)
+        body_roots: List["Node"] = []
+        if loop_node.type in ("for_in_statement", "for_of_statement"):
+            body = loop_node.child_by_field_name("body")
+            if body is not None:
+                body_roots.append(body)
+        elif loop_node.type == "call_expression":
+            callback = self._ts_forEach_callback_node(loop_node)
+            if callback is not None:
+                if callback.type in (
+                    "arrow_function",
+                    "function_expression",
+                    "function",
+                ):
+                    cb_body = callback.child_by_field_name("body")
+                    if cb_body is not None:
+                        body_roots.append(cb_body)
+                    else:
+                        body_roots.append(callback)
+                else:
+                    return False
+
+        found = False
+
+        def visit(node: "Node") -> None:
+            nonlocal found
+            if found:
+                return
+            if node.type == "call_expression":
+                method = self._ts_call_method_name(node)
+                method_lc = method.lower() if method else ""
+                if method_lc in _MCP_REGISTRATION_METHODS:
+                    if self._ts_receiver_is_trusted(
+                        node, method_lc, trusted_receivers
+                    ) and self._ts_call_references_iteration_binding(
+                        node, iteration_names
+                    ):
+                        found = True
+                        return
+            for child in node.children:
+                visit(child)
+
+        for body_root in body_roots:
+            visit(body_root)
+        return found
+
+    def _ts_resolve_handler_reference(
+        self,
+        root: "Node",
+        handler_ref: str,
+        anchor: "Node",
+        func_types: Set[str],
+    ) -> Optional["Node"]:
+        """Resolve ``receiver.method`` / ``this.method`` handler references."""
+        if "." not in handler_ref:
+            return None
+        receiver, method = handler_ref.rsplit(".", 1)
+        if not method:
+            return None
+
+        class_name: Optional[str] = None
+        if receiver == "this":
+            class_name = self._ts_find_enclosing_class_name(anchor)
+        else:
+            class_name = self._ts_resolve_identifier_to_class_name(root, receiver)
+
+        if class_name:
+            return self._ts_find_class_method(root, class_name, method, func_types)
+        return None
+
+    def _ts_resolve_identifier_to_class_name(
+        self, root: "Node", var_name: str
+    ) -> Optional[str]:
+        """Map ``const d = new Dangerous()`` to ``Dangerous``."""
+        found: Optional[str] = None
+
+        def visit(node: "Node") -> None:
+            nonlocal found
+            if found is not None:
+                return
+            if node.type == "variable_declarator":
+                name_node = node.child_by_field_name("name")
+                value_node = node.child_by_field_name("value")
+                if (
+                    name_node is not None
+                    and value_node is not None
+                    and self._ts_get_node_text(name_node) == var_name
+                    and value_node.type == "new_expression"
+                ):
+                    ctor = value_node.child_by_field_name("constructor")
+                    if ctor is None:
+                        for child in value_node.children:
+                            if child.is_named:
+                                ctor = child
+                                break
+                    if ctor is not None:
+                        found = self._ts_get_node_text(ctor).strip().split(".")[-1]
+            for child in node.children:
+                visit(child)
+
+        visit(root)
+        return found
+
+    def _ts_find_class_method(
+        self,
+        root: "Node",
+        class_name: str,
+        method_name: str,
+        func_types: Set[str],
+    ) -> Optional["Node"]:
+        """Find ``method_name`` on the class declaration named ``class_name``."""
+        class_types = self.CLASS_NODE_TYPES.get(self.language, set())
+        target_class: Optional["Node"] = None
+
+        def find_class(node: "Node") -> None:
+            nonlocal target_class
+            if target_class is not None:
+                return
+            if node.type in class_types:
+                name_node = node.child_by_field_name("name")
+                if name_node is not None and self._ts_get_node_text(name_node) == class_name:
+                    target_class = node
+                    return
+            for child in node.children:
+                find_class(child)
+
+        find_class(root)
+        if target_class is None:
+            return None
+
+        method_types = func_types | {"method_definition", "public_field_definition"}
+
+        def find_method(node: "Node") -> Optional["Node"]:
+            if node.type in method_types:
+                name_node = node.child_by_field_name("name")
+                if name_node is not None and self._ts_get_node_text(name_node) == method_name:
+                    return node
+            for child in node.children:
+                hit = find_method(child)
+                if hit is not None:
+                    return hit
+            return None
+
+        return find_method(target_class)
 
     def _ts_is_inside_named_function(
         self, node: "Node", function_names: Set[str]
@@ -3286,6 +3607,10 @@ class NativeAnalyzer:
         def visit(node: "Node") -> None:
             if node.type == "call_expression":
                 callee = self._ts_call_callee_identifier(node)
+                if callee and self._ts_is_parameter_shadow(node, callee):
+                    for child in node.children:
+                        visit(child)
+                    return
                 cap_kind = wrapper_functions.get(callee) if callee else None
                 if cap_kind is not None:
                     args_node = self._ts_call_arguments_node(node)
@@ -3391,7 +3716,8 @@ class NativeAnalyzer:
         *,
         import_target_map: Optional[Dict[str, List[str]]] = None,
         cross_file_analyzer: Optional[Any] = None,
-    ) -> tuple[List[str], List[tuple[int, int]]]:
+        trusted_receivers: Optional[Set[str]] = None,
+    ) -> tuple[List[str], List[Dict[str, Any]]]:
         """Collect static MCP tool names from descriptor arrays.
 
         Only arrays reached through ``for (const tool of api.endpoints)``-style
@@ -3399,13 +3725,14 @@ class NativeAnalyzer:
         array literal would mis-tag HTTP route tables and model catalogues as
         MCP tools.
 
-        Returns ``(tool_names, loop_byte_ranges)`` where each range covers a
-        ``for...of`` / ``forEach`` site that expanded a static table.
+        Returns ``(tool_names, table_loops)`` where each loop entry records
+        the byte range and expanded literal names for that site.
         """
         names: List[str] = []
         seen: Set[str] = set()
-        table_loop_ranges: List[tuple[int, int]] = []
+        table_loops: List[Dict[str, Any]] = []
         bindings = self._ts_build_simple_value_bindings(root)
+        trusted_receivers = trusted_receivers or set()
 
         def add_name(value: Optional[str]) -> None:
             if value and value not in seen:
@@ -3414,7 +3741,13 @@ class NativeAnalyzer:
 
         def record_loop_scope(loop_node: "Node", expanded: List[str]) -> None:
             if expanded:
-                table_loop_ranges.append((loop_node.start_byte, loop_node.end_byte))
+                table_loops.append(
+                    {
+                        "start": loop_node.start_byte,
+                        "end": loop_node.end_byte,
+                        "names": expanded,
+                    }
+                )
 
         def visit(node: "Node") -> None:
             if node.type in ("for_in_statement", "for_of_statement"):
@@ -3427,7 +3760,9 @@ class NativeAnalyzer:
                             import_target_map=import_target_map,
                             cross_file_analyzer=cross_file_analyzer,
                         )
-                    if array_node is not None:
+                    if array_node is not None and self._ts_loop_has_trusted_mcp_registration(
+                        node, trusted_receivers
+                    ):
                         expanded = self._ts_endpoint_names_in_array(array_node)
                         for tool_name in expanded:
                             add_name(tool_name)
@@ -3435,7 +3770,9 @@ class NativeAnalyzer:
             if node.type == "call_expression":
                 if self._ts_call_method_name(node) == "forEach":
                     array_node = self._ts_forEach_source_array(node, bindings, root)
-                    if array_node is not None:
+                    if array_node is not None and self._ts_loop_has_trusted_mcp_registration(
+                        node, trusted_receivers
+                    ):
                         expanded = self._ts_endpoint_names_in_array(array_node)
                         for tool_name in expanded:
                             add_name(tool_name)
@@ -3444,7 +3781,7 @@ class NativeAnalyzer:
                 visit(child)
 
         visit(root)
-        return names, table_loop_ranges
+        return names, table_loops
 
     def _ts_endpoint_names_in_array(self, array_node: "Node") -> List[str]:
         """Return string tool names from object elements in an array literal."""

--- a/tests/behavioral/test_js_code_analyzer_crossfile.py
+++ b/tests/behavioral/test_js_code_analyzer_crossfile.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cross-file capability extraction wiring for JSBehavioralCodeAnalyzer."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcpscanner.core.analyzers.behavioral import js_code_analyzer as jmod
+from mcpscanner.core.static_analysis import NativeAnalyzer
+
+
+class _FakeConfig:
+    def __init__(self, llm_provider_api_key: str = "test-key"):
+        self.llm_provider_api_key = llm_provider_api_key
+        self.llm_model = "gpt-4o-mini"
+        self.llm_base_url = ""
+        self.llm_api_version = ""
+
+
+GRAPH_TOOLS_INDEX = """\
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { api } from "./graph-endpoints.js";
+
+const server = new McpServer({ name: "graph", version: "1.0" });
+
+for (const tool of api.endpoints) {
+  server.tool(
+    tool.alias,
+    tool.description,
+    tool.schema,
+    {},
+    async (params) => ({ content: [{ type: "text", text: "ok" }] }),
+  );
+}
+"""
+
+GRAPH_ENDPOINTS_MODULE = """\
+export const api = {
+  endpoints: [
+    { alias: "list-mail", description: "List mail", schema: {} },
+    { alias: "get-calendar", description: "Get calendar", schema: {} },
+  ],
+};
+"""
+
+
+def test_build_directory_call_graphs_expands_imported_endpoint_aliases(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Directory call graphs must resolve ``tool.alias`` from sibling modules."""
+    index_path = tmp_path / "graph-tools.ts"
+    endpoints_path = tmp_path / "graph-endpoints.ts"
+    index_path.write_text(GRAPH_TOOLS_INDEX)
+    endpoints_path.write_text(GRAPH_ENDPOINTS_MODULE)
+
+    monkeypatch.setattr(jmod, "AlignmentOrchestrator", MagicMock())
+    analyzer = jmod.JSBehavioralCodeAnalyzer(_FakeConfig())
+    files = analyzer._find_js_files(str(tmp_path))
+    call_graphs = analyzer._build_directory_call_graphs(files)
+
+    assert "typescript" in call_graphs
+    caps = NativeAnalyzer(
+        GRAPH_TOOLS_INDEX, str(index_path)
+    ).extract_mcp_capability_contexts(
+        cross_file_analyzer=call_graphs["typescript"]
+    )
+    names = {c.name for c in caps}
+    assert "list-mail" in names, names
+    assert "get-calendar" in names, names
+
+
+def test_analyze_directory_passes_cross_file_analyzer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``analyze(directory)`` must wire cross-file graphs into extraction."""
+    index_path = tmp_path / "graph-tools.ts"
+    endpoints_path = tmp_path / "graph-endpoints.ts"
+    index_path.write_text(GRAPH_TOOLS_INDEX)
+    endpoints_path.write_text(GRAPH_ENDPOINTS_MODULE)
+
+    monkeypatch.setattr(jmod, "AlignmentOrchestrator", MagicMock())
+
+    cross_file_seen: list[bool] = []
+    original_extract = NativeAnalyzer.extract_mcp_capability_contexts
+
+    def _spy_extract(self, cross_file_analyzer=None):
+        cross_file_seen.append(cross_file_analyzer is not None)
+        return original_extract(self, cross_file_analyzer=cross_file_analyzer)
+
+    monkeypatch.setattr(
+        NativeAnalyzer, "extract_mcp_capability_contexts", _spy_extract
+    )
+
+    analyzer = jmod.JSBehavioralCodeAnalyzer(_FakeConfig())
+    asyncio.run(analyzer.analyze(str(tmp_path), {}))
+
+    assert cross_file_seen, "expected at least one extraction pass"
+    assert any(cross_file_seen), "cross_file_analyzer was never passed"

--- a/tests/behavioral/test_js_code_analyzer_crossfile.py
+++ b/tests/behavioral/test_js_code_analyzer_crossfile.py
@@ -115,3 +115,26 @@ def test_analyze_directory_passes_cross_file_analyzer(
 
     assert cross_file_seen, "expected at least one extraction pass"
     assert any(cross_file_seen), "cross_file_analyzer was never passed"
+
+
+def test_build_directory_call_graphs_enforces_aggregate_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Untrusted packages must not load unbounded files into call-graph memory."""
+    for idx in range(jmod._JS_CALL_GRAPH_MAX_FILES + 5):
+        path = tmp_path / f"file-{idx}.ts"
+        path.write_text(
+            "export const x = 1;\n"
+            if idx
+            else 'import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";\n'
+            'const server = new McpServer({ name: "demo", version: "1.0" });\n'
+        )
+
+    monkeypatch.setattr(jmod, "AlignmentOrchestrator", MagicMock())
+    analyzer = jmod.JSBehavioralCodeAnalyzer(_FakeConfig())
+    files = analyzer._find_js_files(str(tmp_path))
+    call_graphs = analyzer._build_directory_call_graphs(files)
+
+    assert analyzer._call_graph_partial is True
+    assert "typescript" in call_graphs
+    assert len(call_graphs["typescript"].files) <= jmod._JS_CALL_GRAPH_MAX_FILES

--- a/tests/static_analysis/test_capability_extraction_crossfile.py
+++ b/tests/static_analysis/test_capability_extraction_crossfile.py
@@ -139,4 +139,10 @@ def test_crossfile_endpoint_table_expands_imported_aliases(tmp_path: Path) -> No
         for c in caps
         if any("registration.table" in t for t in c.decorator_types)
     ]
-    assert len(table_caps) >= 2, [c.decorator_types for c in caps]
+    registration_caps = [
+        c
+        for c in caps
+        if any(t == "<registration>.tool" for t in c.decorator_types)
+    ]
+    assert len(table_caps) == 0, [c.decorator_types for c in caps]
+    assert len(registration_caps) >= 2, [c.decorator_types for c in caps]

--- a/tests/static_analysis/test_capability_extraction_dynamic.py
+++ b/tests/static_analysis/test_capability_extraction_dynamic.py
@@ -425,3 +425,58 @@ def test_ts_bound_method_registration_resolves_bind_handlers() -> None:
     names = {c.name for c in caps}
     assert any("memory_create" in n for n in names), names
     assert any("memory_get" in n for n in names), names
+
+
+JS_LOOP_PLUS_INDEPENDENT_DYNAMIC = """\
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const server = new McpServer({ name: "demo", version: "1.0" });
+
+const tools = [
+  { name: "add", schema: {}, fn: (a, b) => a + b },
+];
+
+tools.forEach((m) => {
+  server.tool(m.name, m.schema, m.fn);
+});
+
+const config = { name: "dynamic-tool" };
+server.tool(config.name, {}, () => ({ content: [{ type: "text", text: "ok" }] }));
+"""
+
+
+def test_table_loop_suppression_does_not_drop_unrelated_dynamic_registration() -> None:
+    """A static forEach table must not suppress unrelated ``config.name`` calls."""
+    analyzer = NativeAnalyzer(JS_LOOP_PLUS_INDEPENDENT_DYNAMIC, "mixed.js")
+    caps = analyzer.extract_mcp_capability_contexts()
+    names = {c.name for c in caps}
+    assert "add" in names, names
+    assert len(caps) == 2, names
+    reg_caps = [
+        c
+        for c in caps
+        if any(t == "<registration>.tool" for t in c.decorator_types)
+    ]
+    assert reg_caps, [c.decorator_types for c in caps]
+
+
+TS_PROMPT_WRAPPER = """\
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const server = new McpServer({ name: "demo", version: "1.0.0" });
+
+function safePrompt(name, schema, handler) {
+  return server.prompt(name, schema, handler);
+}
+
+safePrompt("greet", {}, async () => ({ messages: [] }));
+"""
+
+
+def test_ts_prompt_wrapper_preserves_prompt_capability_kind() -> None:
+    """Wrappers that delegate to ``server.prompt`` must not be tagged as tools."""
+    analyzer = NativeAnalyzer(TS_PROMPT_WRAPPER, "prompt-wrapper.ts")
+    caps = analyzer.extract_mcp_capability_contexts()
+    assert len(caps) == 1, [c.decorator_types for c in caps]
+    assert any("<registration>.prompt" in t for t in caps[0].decorator_types)
+    assert not any("<registration>.tool" in t for t in caps[0].decorator_types)

--- a/tests/static_analysis/test_capability_extraction_dynamic.py
+++ b/tests/static_analysis/test_capability_extraction_dynamic.py
@@ -322,17 +322,14 @@ def test_graph_endpoint_loop_expands_literal_aliases() -> None:
 
 
 def test_graph_loop_inline_handler_uses_alias_not_description() -> None:
-    """The shared inline handler registration must prefer ``tool.alias``."""
+    """Loop registrations with shared inline handlers are covered by table
+    expansion — no duplicate ``tool.alias`` stub."""
     analyzer = NativeAnalyzer(GRAPH_ENDPOINT_LOOP, "graph-tools.ts")
     caps = analyzer.extract_mcp_capability_contexts()
-    reg_caps = [
-        c for c in caps if any(t == "<registration>.tool" for t in c.decorator_types)
-    ]
-    assert reg_caps, [c.decorator_types for c in caps]
-    assert any("tool.alias" in c.name for c in reg_caps), [c.name for c in reg_caps]
-    assert not any(c.name == "toolDescription" for c in reg_caps), [
-        c.name for c in reg_caps
-    ]
+    names = {c.name for c in caps}
+    assert "list-messages" in names, names
+    assert not any("tool.alias" in n for n in names), names
+    assert not any(n == "toolDescription" for n in names), names
 
 
 # ---------------------------------------------------------------------------
@@ -355,16 +352,76 @@ tools.forEach((m) => {
 """
 
 
-def test_js_loop_registration_emits_unresolved_or_inline_handlers() -> None:
-    """``tools.forEach(m => server.tool(m.name, m.schema, m.fn))`` is dynamic.
-
-    Static names from the ``tools`` table are not promoted to capabilities
-    unless that array is reached through an explicit ``for...of`` iteration.
-    """
+def test_js_loop_registration_expands_static_forEach_names() -> None:
+    """``tools.forEach(m => server.tool(m.name, ...))`` must expand literal
+    tool names from the static ``tools`` table."""
     analyzer = NativeAnalyzer(JS_LOOP_REGISTRATION, "loop.js")
     caps = analyzer.extract_mcp_capability_contexts()
     names = {c.name for c in caps}
-    assert names == {"m.name"}, names
-    assert any(
-        any("registration.unresolved" in t for t in c.decorator_types) for c in caps
-    ), [c.decorator_types for c in caps]
+    assert names == {"add", "sub"}, names
+    table_caps = [
+        c
+        for c in caps
+        if any("registration.table" in t for t in c.decorator_types)
+    ]
+    assert len(table_caps) == 2, [c.decorator_types for c in caps]
+
+
+TS_CUSTOM_WRAPPER = """\
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+const server = new McpServer({ name: "demo", version: "1.0.0" });
+
+function safeTool(
+  name: string,
+  schema: Record<string, z.ZodTypeAny>,
+  handler: (args: any) => Promise<{ content: Array<{ type: "text"; text: string }> }>,
+) {
+  return server.tool(name, schema, handler);
+}
+
+safeTool(
+  "greet",
+  { name: z.string() },
+  async ({ name }) => ({ content: [{ type: "text", text: `hello ${name}` }] }),
+);
+"""
+
+
+def test_ts_custom_wrapper_uses_literal_tool_name() -> None:
+    """``safeTool('greet', schema, handler)`` must not pick schema key ``name``."""
+    analyzer = NativeAnalyzer(TS_CUSTOM_WRAPPER, "wrapper.ts")
+    caps = analyzer.extract_mcp_capability_contexts()
+    names = {c.name for c in caps}
+    assert names == {"greet"}, names
+
+
+TS_BOUND_METHOD_REGISTRATION = """\
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+class ControlPlaneTools {
+  async memoryCreate(args: { name: string }) {
+    return { content: [{ type: "text", text: args.name }] };
+  }
+
+  async memoryGet(args: { name: string }) {
+    return { content: [{ type: "text", text: args.name }] };
+  }
+
+  register(mcp: McpServer) {
+    mcp.tool("memory_create", { name: z.string() }, this.memoryCreate.bind(this));
+    mcp.tool("memory_get", { name: z.string() }, this.memoryGet.bind(this));
+  }
+}
+"""
+
+
+def test_ts_bound_method_registration_resolves_bind_handlers() -> None:
+    """``mcp.tool('memory_create', schema, this.method.bind(this))`` must classify."""
+    analyzer = NativeAnalyzer(TS_BOUND_METHOD_REGISTRATION, "controlplane.ts")
+    caps = analyzer.extract_mcp_capability_contexts()
+    names = {c.name for c in caps}
+    assert any("memory_create" in n for n in names), names
+    assert any("memory_get" in n for n in names), names

--- a/tests/static_analysis/test_capability_extraction_dynamic.py
+++ b/tests/static_analysis/test_capability_extraction_dynamic.py
@@ -449,15 +449,19 @@ def test_table_loop_suppression_does_not_drop_unrelated_dynamic_registration() -
     """A static forEach table must not suppress unrelated ``config.name`` calls."""
     analyzer = NativeAnalyzer(JS_LOOP_PLUS_INDEPENDENT_DYNAMIC, "mixed.js")
     caps = analyzer.extract_mcp_capability_contexts()
-    names = {c.name for c in caps}
-    assert "add" in names, names
-    assert len(caps) == 2, names
-    reg_caps = [
+    table_caps = [
+        c
+        for c in caps
+        if any("registration.table" in t for t in c.decorator_types)
+    ]
+    dynamic_caps = [
         c
         for c in caps
         if any(t == "<registration>.tool" for t in c.decorator_types)
     ]
-    assert reg_caps, [c.decorator_types for c in caps]
+    assert [c.name for c in table_caps] == ["add"], [c.name for c in caps]
+    assert len(dynamic_caps) == 1, [c.name for c in caps]
+    assert "config.name" in dynamic_caps[0].name, dynamic_caps[0].name
 
 
 TS_PROMPT_WRAPPER = """\

--- a/tests/static_analysis/test_capability_extraction_dynamic.py
+++ b/tests/static_analysis/test_capability_extraction_dynamic.py
@@ -318,7 +318,13 @@ def test_graph_endpoint_loop_expands_literal_aliases() -> None:
         for c in caps
         if any("registration.table" in t for t in c.decorator_types)
     ]
-    assert len(table_caps) >= 3, [c.decorator_types for c in caps]
+    registration_caps = [
+        c
+        for c in caps
+        if any(t == "<registration>.tool" for t in c.decorator_types)
+    ]
+    assert len(table_caps) == 0, [c.decorator_types for c in caps]
+    assert len(registration_caps) >= 3, [c.decorator_types for c in caps]
 
 
 def test_graph_loop_inline_handler_uses_alias_not_description() -> None:
@@ -484,3 +490,123 @@ def test_ts_prompt_wrapper_preserves_prompt_capability_kind() -> None:
     assert len(caps) == 1, [c.decorator_types for c in caps]
     assert any("<registration>.prompt" in t for t in caps[0].decorator_types)
     assert not any("<registration>.tool" in t for t in caps[0].decorator_types)
+
+
+# ---------------------------------------------------------------------------
+# PR review regressions (table loops, bind handlers, receiver trust).
+# ---------------------------------------------------------------------------
+
+TABLE_LOOP_INLINE_HANDLER = """\
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { execSync } from "node:child_process";
+
+const server = new McpServer({ name: "demo", version: "1.0" });
+const tools = [{ name: "run_cmd", schema: {}, description: "run" }];
+
+tools.forEach((m) => {
+  server.tool(m.name, m.schema, async ({ command }) => execSync(command));
+});
+"""
+
+
+def test_table_loop_inline_handler_preserves_executable_evidence() -> None:
+    """Shared inline handlers in table loops must not collapse to name-only stubs."""
+    analyzer = NativeAnalyzer(TABLE_LOOP_INLINE_HANDLER, "loop-inline.js")
+    caps = analyzer.extract_mcp_capability_contexts()
+    assert len(caps) == 1, [(c.name, c.decorator_types) for c in caps]
+    cap = caps[0]
+    assert cap.name == "run_cmd", cap.name
+    assert any("<registration>.tool" in t for t in cap.decorator_types), cap.decorator_types
+    assert not any("registration.table" in t for t in cap.decorator_types)
+    call_names = {c.get("name") for c in cap.function_calls or []}
+    assert "execSync" in call_names, call_names
+    assert cap.has_subprocess_calls is True
+
+
+BOUND_METHOD_CLASS_RESOLUTION = """\
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+class Safe {
+  run() {
+    return "safe";
+  }
+}
+
+class Dangerous {
+  run() {
+    eval("1");
+    return "danger";
+  }
+}
+
+const server = new McpServer({ name: "demo", version: "1.0" });
+const d = new Dangerous();
+server.tool("ghost", {}, d.run.bind(d));
+"""
+
+
+def test_bind_handler_resolves_receiver_class_not_first_same_named_method() -> None:
+    """``d.run.bind(d)`` must resolve to ``Dangerous.run``, not an earlier ``Safe.run``."""
+    analyzer = NativeAnalyzer(BOUND_METHOD_CLASS_RESOLUTION, "bind-class.js")
+    caps = analyzer.extract_mcp_capability_contexts()
+    assert len(caps) == 1, [c.name for c in caps]
+    cap = caps[0]
+    assert "Dangerous.run" in cap.name, cap.name
+    call_names = {c.get("name") for c in cap.function_calls or []}
+    assert "eval" in call_names, call_names
+
+
+NON_MCP_FOREACH_TABLE = """\
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const server = new McpServer({ name: "demo", version: "1.0" });
+const models = [{ name: "gpt-prod", description: "model config" }];
+models.forEach(console.log);
+"""
+
+
+def test_non_mcp_foreach_tables_are_not_expanded() -> None:
+    """``models.forEach(console.log)`` must not emit MCP tool stubs."""
+    analyzer = NativeAnalyzer(NON_MCP_FOREACH_TABLE, "models.js")
+    caps = analyzer.extract_mcp_capability_contexts()
+    assert caps == [], [(c.name, c.decorator_types) for c in caps]
+
+
+UNTRUSTED_NESTED_SERVER_RECEIVER = """\
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const server = new McpServer({ name: "demo", version: "1.0" });
+const attacker = { server: { tool: (n, s, h) => {} } };
+attacker.server.tool("ghost", {}, () => {});
+"""
+
+
+def test_untrusted_nested_server_receiver_is_ignored() -> None:
+    """``attacker.server.tool`` must not be trusted just because ``server`` appears."""
+    analyzer = NativeAnalyzer(UNTRUSTED_NESTED_SERVER_RECEIVER, "decoy.js")
+    caps = analyzer.extract_mcp_capability_contexts()
+    assert caps == [], [(c.name, c.decorator_types) for c in caps]
+
+
+SHADOWED_WRAPPER_PARAMETER = """\
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const server = new McpServer({ name: "demo", version: "1.0" });
+
+function safeTool(name, schema, handler) {
+  return server.tool(name, schema, handler);
+}
+
+function caller(safeTool) {
+  safeTool("ghost", {}, () => eval("1"));
+}
+
+caller(() => {});
+"""
+
+
+def test_shadowed_wrapper_parameter_is_not_treated_as_registration() -> None:
+    """Parameters named like a wrapper must not inherit wrapper registration semantics."""
+    analyzer = NativeAnalyzer(SHADOWED_WRAPPER_PARAMETER, "shadow-wrapper.js")
+    caps = analyzer.extract_mcp_capability_contexts()
+    assert caps == [], [(c.name, c.decorator_types) for c in caps]


### PR DESCRIPTION
Resolve safeTool-style wrappers, bound class methods, forEach table expansion, and cross-file endpoint loops so static scans report literal tool names instead of parameter or member-expression stubs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded capability detection for wrapper functions, bound methods, class properties, and broader handler patterns.
  * Added support for loop-based and table-driven endpoint registrations.
  * Improved cross-file JavaScript and TypeScript analysis, including imported endpoint aliases.
  * Added safeguards for large directory scans while continuing analysis with available results.
* **Bug Fixes**
  * Reduced unresolved names and description placeholders.
  * Prevented duplicate registrations and excluded internal wrapper details.
* **Tests**
  * Added coverage for wrappers, bound handlers, loops, aliases, and cross-file analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->