### PR TITLE
feat(cli): add static-source subcommand for no-LLM YARA source scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,39 @@ mcp-scanner behavioral /path/to/mcp_server.py --output results.json --format raw
 ```
 
 
+> **Note:** `behavioral` always performs LLM-powered alignment checking, so it
+> requires an LLM provider key. For pattern detection over source code with no
+> LLM provider and no running server, use `static-source` below.
+
 See [Behavioral Scanning Documentation](https://github.com/cisco-ai-defense/mcp-scanner/tree/main/docs/behavioral-scanning.md) for complete technical details.
+
+#### Source Code Scanning Without an LLM (`static-source`)
+
+`static-source` runs the YARA rules directly over a source file or directory.
+It needs no LLM provider key and no running MCP server, which makes it usable
+in CI on a feature branch without per-pull-request LLM spend.
+
+Unlike `static`, which reads pre-captured `tools/list` JSON, this scans raw
+source. Unlike `behavioral`, it performs no alignment checking — it is pattern
+detection only, so it will not catch docstring/behavior mismatches.
+
+```bash
+# Scan a directory of source
+mcp-scanner static-source /path/to/mcp_server_src/
+
+# Scan a single file
+mcp-scanner static-source /path/to/server.py
+
+# Custom YARA rules
+mcp-scanner static-source /path/to/src --rules-path /path/to/rules/
+
+# CI-friendly: machine-readable output
+mcp-scanner static-source /path/to/src --output findings.json --format raw
+```
+
+Every scanned file appears in the output, including clean ones (`"is_safe":
+true`), so a report distinguishes "examined and clean" from "never examined". A
+file whose scan fails is reported with status `error` rather than as clean.
 
 #### PyPI Package Scanning
 

--- a/mcpscanner/cli.py
+++ b/mcpscanner/cli.py
@@ -1255,6 +1255,14 @@ async def main():
         default="summary",
         help="Output format (default: %(default)s)",
     )
+    # Also accepted after the subcommand, since that is the natural order for
+    # `static-source SRC --rules-path RULES`. SUPPRESS keeps the subparser from
+    # overwriting a value already given before the subcommand.
+    p_static_source.add_argument(
+        "--rules-path",
+        default=argparse.SUPPRESS,
+        help="Path to directory containing custom YARA rules",
+    )
 
     # Behavioral subcommand - scan local source code
     p_behavioral = subparsers.add_parser(
@@ -2313,6 +2321,11 @@ async def main():
             # a Config or any LLM-backed analyzer: this path must work with no
             # LLM provider key and no running MCP server.
             from mcpscanner.core.source_scan import scan_source_with_yara
+
+            # YARA is the only analyzer that runs here, so the report must not
+            # credit the default api,yara,llm set — otherwise `--format table`
+            # renders API and LLM as SAFE for analyzers that never ran.
+            selected_analyzers = [AnalyzerEnum.YARA]
 
             try:
                 results = await scan_source_with_yara(

--- a/mcpscanner/cli.py
+++ b/mcpscanner/cli.py
@@ -1064,6 +1064,10 @@ async def main():
   %(prog)s static --prompts prompts.json --analyzers llm                     # Scan prompts file
   %(prog)s static --resources resources.json --analyzers yara                # Scan resources file
   %(prog)s static --tools t.json --prompts p.json --analyzers yara,llm,api   # Scan all three types
+
+  # Source code scanning with no LLM key and no running server:
+  %(prog)s static-source /path/to/src                                        # YARA rules over a source tree
+  %(prog)s static-source /path/to/server.py --format raw -o findings.json    # Machine-readable output for CI
         """,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -1206,6 +1210,47 @@ async def main():
         choices=[
             "raw", "summary", "detailed", "by_tool",
             "by_analyzer", "by_severity", "table",
+        ],
+        default="summary",
+        help="Output format (default: %(default)s)",
+    )
+
+    # static-source subcommand - YARA over raw source, no LLM key required
+    p_static_source = subparsers.add_parser(
+        "static-source",
+        help=(
+            "Scan MCP server source code with YARA rules only "
+            "(no LLM key or running server required)"
+        ),
+    )
+    p_static_source.add_argument(
+        "source_path",
+        help="Path to MCP server source code file or directory",
+    )
+    p_static_source.add_argument(
+        "--output",
+        "-o",
+        help="Save scan results to a file",
+    )
+    p_static_source.add_argument(
+        "--verbose", "-v", action="store_true", help="Print verbose output"
+    )
+    p_static_source.add_argument(
+        "--raw", "-r", action="store_true", help="Print raw JSON output"
+    )
+    p_static_source.add_argument(
+        "--detailed", "-d", action="store_true", help="Show detailed results"
+    )
+    p_static_source.add_argument(
+        "--format",
+        choices=[
+            "raw",
+            "summary",
+            "detailed",
+            "by_tool",
+            "by_analyzer",
+            "by_severity",
+            "table",
         ],
         default="summary",
         help="Output format (default: %(default)s)",
@@ -2263,6 +2308,27 @@ async def main():
                 if args.verbose:
                     print(f"Results saved to {args.output}")
 
+        elif args.cmd == "static-source":
+            # YARA-only scan over raw source. Deliberately does NOT construct
+            # a Config or any LLM-backed analyzer: this path must work with no
+            # LLM provider key and no running MCP server.
+            from mcpscanner.core.source_scan import scan_source_with_yara
+
+            try:
+                results = await scan_source_with_yara(
+                    args.source_path,
+                    rules_dir=args.rules_path,
+                )
+            except FileNotFoundError as e:
+                print(f"Error: {e}", file=sys.stderr)
+                sys.exit(1)
+
+            if args.output:
+                with open(args.output, "w", encoding="utf-8") as f:
+                    json.dump(results, f, indent=2)
+                if args.verbose:
+                    print(f"Results saved to {args.output}")
+
         elif args.cmd == "pypi-scan":
             from mcpscanner.core.pypi_scanner import (
                 DockerNotAvailableError,
@@ -2627,6 +2693,8 @@ async def main():
             server_label = f"vulnerable-package:{args.scan_path}"
         elif hasattr(args, "cmd") and args.cmd == "behavioral":
             server_label = f"behavioral:{args.source_path}"
+        elif hasattr(args, "cmd") and args.cmd == "static-source":
+            server_label = f"static-source:{args.source_path}"
         elif hasattr(args, "cmd") and args.cmd == "pypi-scan":
             pkg_spec = args.package
             if getattr(args, "version", None):
@@ -2758,6 +2826,8 @@ async def main():
             server_label = "well-known-configs"
         elif hasattr(args, "cmd") and args.cmd == "behavioral":
             server_label = f"behavioral:{args.source_path}"
+        elif hasattr(args, "cmd") and args.cmd == "static-source":
+            server_label = f"static-source:{args.source_path}"
         elif hasattr(args, "cmd") and args.cmd == "pypi-scan":
             pkg_spec = args.package
             if getattr(args, "version", None):

--- a/mcpscanner/core/analyzers/behavioral/code_analyzer.py
+++ b/mcpscanner/core/analyzers/behavioral/code_analyzer.py
@@ -39,6 +39,11 @@ from ....config.constants import MCPScannerConstants
 from ....threats.threats import ThreatMapping
 from ....utils.log_format import sanitize_log_value, truncate
 from ....utils.path_safety import filter_safe_paths, safe_resolve_root
+from ...source_discovery import (
+    EXT_TO_TS_LANGUAGE,
+    PYTHON_EXTENSIONS,
+    find_source_files,
+)
 from ...static_analysis.context_extractor import ContextExtractor, FunctionContext
 from ...static_analysis.native_analyzer import NativeAnalyzer
 from ...static_analysis.interprocedural.call_graph_analyzer import CallGraphAnalyzer
@@ -526,25 +531,18 @@ class BehavioralCodeAnalyzer(BaseAnalyzer):
             )
             return []
 
-    _EXT_TO_TS_LANGUAGE = {
-        ".js": "javascript", ".jsx": "javascript", ".mjs": "javascript", ".cjs": "javascript",
-        ".ts": "typescript", ".tsx": "typescript", ".mts": "typescript", ".cts": "typescript",
-        ".go": "go",
-        ".java": "java",
-        ".kt": "kotlin", ".kts": "kotlin",
-        ".cs": "c_sharp",
-        ".rb": "ruby", ".rake": "ruby", ".gemspec": "ruby",
-        ".rs": "rust",
-        ".php": "php", ".phtml": "php",
-    }
+    # Sourced from ``core.source_discovery`` so this analyzer and the no-LLM
+    # YARA source scan cannot drift on which extensions count as source.
+    _EXT_TO_TS_LANGUAGE = EXT_TO_TS_LANGUAGE
 
-    _PYTHON_EXTENSIONS = {".py", ".pyw"}
+    _PYTHON_EXTENSIONS = PYTHON_EXTENSIONS
 
     def _find_source_files(self, directory: str) -> List[str]:
         """Find all supported source files in a directory.
 
-        Supports Python, TypeScript, JavaScript, Go, Java, Kotlin, C#, Ruby,
-        Rust, and PHP files.
+        Delegates to :func:`mcpscanner.core.source_discovery.find_source_files`
+        so this path and the no-LLM YARA source scan agree on which files
+        count as source and on symlink-escape filtering.
 
         Args:
             directory: Directory path to search
@@ -552,34 +550,7 @@ class BehavioralCodeAnalyzer(BaseAnalyzer):
         Returns:
             List of source file paths
         """
-        source_files = []
-        path = Path(directory)
-        resolved_root = safe_resolve_root(directory)
-
-        extensions = self._PYTHON_EXTENSIONS | set(self._EXT_TO_TS_LANGUAGE.keys())
-
-        candidates: List[Path] = []
-        for ext in extensions:
-            for source_file in path.rglob(f"*{ext}"):
-                # Inspect only components below the scan root; an absolute
-                # ``parts`` would treat a hidden ancestor dir (e.g. a dotted
-                # TMPDIR) as reason to skip every file, silently emptying
-                # the scan.
-                rel_parts = _relative_parts(source_file, path)
-                if (
-                    "__pycache__" not in rel_parts
-                    and "node_modules" not in rel_parts
-                    and not any(part.startswith(".") for part in rel_parts)
-                ):
-                    candidates.append(source_file)
-
-        safe_candidates, _skipped = filter_safe_paths(
-            candidates, resolved_root, audit_label="behavioral"
-        )
-        for source_file in safe_candidates:
-            source_files.append(str(source_file))
-
-        return sorted(source_files)
+        return find_source_files(directory, audit_label="behavioral")
 
     def _prefilter_capability_files(
         self, source_files: List[str]

--- a/mcpscanner/core/source_discovery.py
+++ b/mcpscanner/core/source_discovery.py
@@ -1,0 +1,111 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Source-tree discovery shared by the source-scanning code paths.
+
+This module is deliberately dependency-light: it imports nothing that pulls
+in an LLM SDK. The behavioural analyzer's module graph reaches ``litellm``,
+which costs roughly 11 seconds and ~880 modules to import, so a no-LLM YARA
+scan must not have to import it just to walk a directory.
+
+Both :mod:`mcpscanner.core.source_scan` and the behavioural analyzer use the
+definitions here, keeping one source of truth for which extensions count as
+source and for symlink-escape filtering.
+"""
+
+from pathlib import Path
+from typing import Dict, List, Set
+
+from ..utils.path_safety import filter_safe_paths, safe_resolve_root
+
+# Extension -> tree-sitter language name.
+EXT_TO_TS_LANGUAGE: Dict[str, str] = {
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".mts": "typescript",
+    ".cts": "typescript",
+    ".go": "go",
+    ".java": "java",
+    ".kt": "kotlin",
+    ".kts": "kotlin",
+    ".cs": "c_sharp",
+    ".rb": "ruby",
+    ".rake": "ruby",
+    ".gemspec": "ruby",
+    ".rs": "rust",
+    ".php": "php",
+    ".phtml": "php",
+}
+
+PYTHON_EXTENSIONS: Set[str] = {".py", ".pyw"}
+
+# Directories never worth walking into: build artefacts and dependency trees.
+_EXCLUDED_DIR_NAMES = frozenset({"__pycache__", "node_modules"})
+
+
+def relative_parts(file_path: Path, root: Path) -> tuple[str, ...]:
+    """Return ``file_path``'s path components relative to ``root``.
+
+    Skip/hidden heuristics must only consider directories *inside* the
+    scanned tree. Using the absolute ``Path.parts`` would also inspect
+    ancestors of ``root`` (e.g. a hidden ``TMPDIR`` such as
+    ``/Users/me/.cache/T/...``) and wrongly drop every file. Falls back to
+    the absolute parts only if ``file_path`` is somehow not under ``root``.
+    """
+    try:
+        return file_path.relative_to(root).parts
+    except ValueError:  # pragma: no cover - rglob results stay under root
+        return file_path.parts
+
+
+def find_source_files(directory: str, *, audit_label: str = "scan") -> List[str]:
+    """Find all supported source files under ``directory``.
+
+    Supports Python, TypeScript, JavaScript, Go, Java, Kotlin, C#, Ruby,
+    Rust, and PHP. Skips ``__pycache__``, ``node_modules`` and any
+    dot-directory inside the scan root, then drops candidates whose
+    resolved path escapes the root via a symlink.
+
+    Args:
+        directory: Directory path to search.
+        audit_label: Label used when logging rejected symlink escapes.
+
+    Returns:
+        Sorted list of source file paths.
+    """
+    path = Path(directory)
+    resolved_root = safe_resolve_root(directory)
+
+    extensions = PYTHON_EXTENSIONS | set(EXT_TO_TS_LANGUAGE.keys())
+
+    candidates: List[Path] = []
+    for ext in extensions:
+        for source_file in path.rglob(f"*{ext}"):
+            rel_parts = relative_parts(source_file, path)
+            if any(part in _EXCLUDED_DIR_NAMES for part in rel_parts):
+                continue
+            if any(part.startswith(".") for part in rel_parts):
+                continue
+            candidates.append(source_file)
+
+    safe_candidates, _skipped = filter_safe_paths(
+        candidates, resolved_root, audit_label=audit_label
+    )
+    return sorted(str(p) for p in safe_candidates)

--- a/mcpscanner/core/source_scan.py
+++ b/mcpscanner/core/source_scan.py
@@ -29,8 +29,7 @@ branch without per-pull-request LLM spend.
 import asyncio
 import logging
 import os
-from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from ..config.constants import MCPScannerConstants
 from ..utils.log_format import sanitize_log_value
@@ -44,30 +43,51 @@ from .source_discovery import find_source_files
 
 logger = logging.getLogger(__name__)
 
+# Severity for a file we failed to examine. ``UNKNOWN`` is the codebase's
+# existing "analyzer didn't run" value (see ``result.get_highest_severity``),
+# so error rows sort and render through every formatter unchanged. A bespoke
+# ``ERROR`` severity would be dropped by ``--format by_severity``, which only
+# iterates the known ordering.
+_NOT_EXAMINED = "UNKNOWN"
 
-def _read_source_text(path: str) -> Optional[str]:
-    """Read ``path`` as text, or return ``None`` if it should be skipped.
+_SEVERITY_RANK = {"HIGH": 3, "MEDIUM": 2, "LOW": 1, "INFO": 1, "SAFE": 0, "UNKNOWN": 0}
 
-    Files larger than five times ``MAX_FILE_SIZE_BYTES`` are skipped, matching
-    the behavioral prefilter's ceiling. Undecodable bytes are replaced rather
-    than raising, because YARA rules are still useful against partially
-    binary content.
+
+def _read_source_text(path: str) -> Tuple[Optional[str], Optional[str]]:
+    """Read ``path`` as text.
+
+    Returns ``(text, error)`` where exactly one side is set, or ``(None,
+    None)`` for a deliberate skip:
+
+    * ``(text, None)`` — read succeeded.
+    * ``(None, None)`` — file exceeds the size ceiling, skipped on purpose.
+    * ``(None, message)`` — read failed; the caller must surface this rather
+      than omit the file, or an unreadable tree would report as clean.
+
+    Undecodable bytes are replaced rather than raising, because YARA rules are
+    still useful against partially binary content.
     """
     try:
         if os.path.getsize(path) > MCPScannerConstants.MAX_FILE_SIZE_BYTES * 5:
             logger.debug("source scan skipping huge file: %s", sanitize_log_value(path))
-            return None
+            return None, None
         with open(path, "rb") as handle:
-            return handle.read().decode("utf-8", errors="replace")
+            return handle.read().decode("utf-8", errors="replace"), None
     except OSError as exc:
-        logger.debug("source scan could not read %s: %s", sanitize_log_value(path), exc)
-        return None
+        logger.warning(
+            "source scan could not read %s: %s", sanitize_log_value(path), exc
+        )
+        return None, str(exc)
 
 
-def _result_for_file(
+def _row(
     display_name: str,
     source_file: str,
-    findings: List[SecurityFinding],
+    *,
+    severity: str,
+    summary: str,
+    threat_names: Sequence[str] = (),
+    total_findings: int = 0,
     status: str = "completed",
 ) -> Dict[str, Any]:
     """Build one report-generator-compatible result row for a scanned file.
@@ -75,47 +95,48 @@ def _result_for_file(
     The shape mirrors the rows produced for behavioral scans so the existing
     ``--format`` renderers and ``--analyzer-filter`` grouping work unchanged.
     Findings are keyed under ``yara_analyzer`` to match the analyzer name the
-    report generator filters on.
+    report generator filters on. ``is_safe`` is derived from ``severity`` so a
+    file we failed to examine can never be reported as clean.
     """
-    if not findings:
-        return {
-            "tool_name": display_name,
-            "tool_description": f"Source file {display_name}",
-            "status": status,
-            "is_safe": True,
-            "findings": {
-                "yara_analyzer": {
-                    "severity": "SAFE",
-                    "threat_summary": "No YARA rule matches detected",
-                    "threat_names": [],
-                    "total_findings": 0,
-                    "source_file": source_file,
-                }
-            },
-        }
-
-    severity_order = {"HIGH": 3, "MEDIUM": 2, "LOW": 1, "SAFE": 0, "UNKNOWN": 0}
-    max_severity = max(
-        (f.severity for f in findings),
-        key=lambda s: severity_order.get(s, 0),
-    )
     return {
         "tool_name": display_name,
         "tool_description": f"Source file {display_name}",
         "status": status,
-        "is_safe": max_severity == "SAFE",
+        "is_safe": severity == "SAFE",
         "findings": {
             "yara_analyzer": {
-                "severity": max_severity,
-                "threat_summary": findings[0].summary,
-                "threat_names": sorted(
-                    {f.threat_category for f in findings if f.threat_category}
-                ),
-                "total_findings": len(findings),
+                "severity": severity,
+                "threat_summary": summary,
+                "threat_names": list(threat_names),
+                "total_findings": total_findings,
                 "source_file": source_file,
             }
         },
     }
+
+
+def _match_row(
+    display_name: str, source_file: str, findings: List[SecurityFinding]
+) -> Dict[str, Any]:
+    """Build the row for a file whose scan completed, matches or not."""
+    if not findings:
+        return _row(
+            display_name,
+            source_file,
+            severity="SAFE",
+            summary="No YARA rule matches detected",
+        )
+
+    return _row(
+        display_name,
+        source_file,
+        severity=max(
+            (f.severity for f in findings), key=lambda s: _SEVERITY_RANK.get(s, 0)
+        ),
+        summary=findings[0].summary,
+        threat_names=sorted({f.threat_category for f in findings if f.threat_category}),
+        total_findings=len(findings),
+    )
 
 
 async def scan_source_with_yara(
@@ -131,10 +152,10 @@ async def scan_source_with_yara(
 
     Returns:
         One result row per scanned file, including clean files (``is_safe``
-        ``True``) so the output enumerates everything that was examined
-        rather than only what matched. A file whose YARA scan raises is
-        reported with status ``error`` and severity ``ERROR`` rather than
-        being silently dropped or misreported as clean.
+        ``True``) so the output enumerates everything that was examined rather
+        than only what matched. A file that could not be read, or whose YARA
+        scan raised, is reported ``status="error"`` with severity ``UNKNOWN``
+        rather than being dropped or misreported as clean.
 
     Raises:
         FileNotFoundError: If ``source_path`` does not exist.
@@ -143,11 +164,12 @@ async def scan_source_with_yara(
         raise FileNotFoundError(f"Source path not found: {source_path}")
 
     analyzer = YaraAnalyzer(rules_dir=rules_dir)
-
-    if os.path.isfile(source_path):
-        source_files = [source_path]
-    else:
-        source_files = await asyncio.to_thread(find_source_files, source_path)
+    is_dir = os.path.isdir(source_path)
+    source_files = (
+        await asyncio.to_thread(find_source_files, source_path)
+        if is_dir
+        else [source_path]
+    )
 
     logger.info(
         "yara source scan start target=%s files=%d",
@@ -159,12 +181,25 @@ async def scan_source_with_yara(
     for source_file in source_files:
         display_name = (
             os.path.relpath(source_file, source_path)
-            if os.path.isdir(source_path)
+            if is_dir
             else os.path.basename(source_file)
         )
 
-        source_text = await asyncio.to_thread(_read_source_text, source_file)
-        if source_text is None:
+        source_text, read_error = await asyncio.to_thread(
+            _read_source_text, source_file
+        )
+        if read_error is not None:
+            results.append(
+                _row(
+                    display_name,
+                    source_file,
+                    severity=_NOT_EXAMINED,
+                    summary=f"Source file could not be read: {read_error}",
+                    status="error",
+                )
+            )
+            continue
+        if source_text is None:  # oversized: skipped deliberately
             continue
 
         try:
@@ -173,32 +208,23 @@ async def scan_source_with_yara(
                 context={"tool_name": display_name, "content_type": "source_code"},
             )
         except Exception as exc:
-            # A rule-matching failure means this file was never examined.
-            # Reporting it as clean would make a gather failure
-            # indistinguishable from evidence of safety, so surface it.
+            # Failure to gather evidence must not look like evidence of
+            # compliance, so the file is surfaced instead of dropped.
             logger.error(
                 "YARA scan failed for %s: %s", sanitize_log_value(source_file), exc
             )
             results.append(
-                {
-                    "tool_name": display_name,
-                    "tool_description": f"Source file {display_name}",
-                    "status": "error",
-                    "is_safe": False,
-                    "findings": {
-                        "yara_analyzer": {
-                            "severity": "ERROR",
-                            "threat_summary": f"YARA scan failed: {exc}",
-                            "threat_names": [],
-                            "total_findings": 0,
-                            "source_file": source_file,
-                        }
-                    },
-                }
+                _row(
+                    display_name,
+                    source_file,
+                    severity=_NOT_EXAMINED,
+                    summary=f"YARA scan failed: {exc}",
+                    status="error",
+                )
             )
             continue
 
-        results.append(_result_for_file(display_name, source_file, findings))
+        results.append(_match_row(display_name, source_file, findings))
 
     if not results:
         results.append(
@@ -211,11 +237,11 @@ async def scan_source_with_yara(
             }
         )
 
-    matched = sum(1 for r in results if not r.get("is_safe", True))
+    flagged = sum(1 for r in results if not r.get("is_safe", True))
     logger.info(
         "yara source scan done target=%s scanned=%d flagged=%d",
         sanitize_log_value(source_path),
         len(results),
-        matched,
+        flagged,
     )
     return results

--- a/mcpscanner/core/source_scan.py
+++ b/mcpscanner/core/source_scan.py
@@ -1,0 +1,221 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""No-LLM YARA scanning over raw source directories.
+
+The ``behavioral`` scan path pairs static analysis with an LLM alignment
+check, so it cannot run without LLM credentials. This module provides the
+pattern-only half of that pipeline: it walks a source tree and runs the
+existing YARA rules over each file's contents, with no LLM provider and no
+running MCP server required.
+
+That makes CI usable for teams that want pattern detection on a feature
+branch without per-pull-request LLM spend.
+"""
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ..config.constants import MCPScannerConstants
+from ..utils.log_format import sanitize_log_value
+from .analyzers.base import SecurityFinding
+from .analyzers.yara_analyzer import YaraAnalyzer
+
+# Traversal lives in its own dependency-light module on purpose: importing the
+# behavioural analyzer would pull in ``litellm`` (~11s, ~880 modules), which
+# would defeat the point of a no-LLM scan path.
+from .source_discovery import find_source_files
+
+logger = logging.getLogger(__name__)
+
+
+def _read_source_text(path: str) -> Optional[str]:
+    """Read ``path`` as text, or return ``None`` if it should be skipped.
+
+    Files larger than five times ``MAX_FILE_SIZE_BYTES`` are skipped, matching
+    the behavioral prefilter's ceiling. Undecodable bytes are replaced rather
+    than raising, because YARA rules are still useful against partially
+    binary content.
+    """
+    try:
+        if os.path.getsize(path) > MCPScannerConstants.MAX_FILE_SIZE_BYTES * 5:
+            logger.debug("source scan skipping huge file: %s", sanitize_log_value(path))
+            return None
+        with open(path, "rb") as handle:
+            return handle.read().decode("utf-8", errors="replace")
+    except OSError as exc:
+        logger.debug("source scan could not read %s: %s", sanitize_log_value(path), exc)
+        return None
+
+
+def _result_for_file(
+    display_name: str,
+    source_file: str,
+    findings: List[SecurityFinding],
+    status: str = "completed",
+) -> Dict[str, Any]:
+    """Build one report-generator-compatible result row for a scanned file.
+
+    The shape mirrors the rows produced for behavioral scans so the existing
+    ``--format`` renderers and ``--analyzer-filter`` grouping work unchanged.
+    Findings are keyed under ``yara_analyzer`` to match the analyzer name the
+    report generator filters on.
+    """
+    if not findings:
+        return {
+            "tool_name": display_name,
+            "tool_description": f"Source file {display_name}",
+            "status": status,
+            "is_safe": True,
+            "findings": {
+                "yara_analyzer": {
+                    "severity": "SAFE",
+                    "threat_summary": "No YARA rule matches detected",
+                    "threat_names": [],
+                    "total_findings": 0,
+                    "source_file": source_file,
+                }
+            },
+        }
+
+    severity_order = {"HIGH": 3, "MEDIUM": 2, "LOW": 1, "SAFE": 0, "UNKNOWN": 0}
+    max_severity = max(
+        (f.severity for f in findings),
+        key=lambda s: severity_order.get(s, 0),
+    )
+    return {
+        "tool_name": display_name,
+        "tool_description": f"Source file {display_name}",
+        "status": status,
+        "is_safe": max_severity == "SAFE",
+        "findings": {
+            "yara_analyzer": {
+                "severity": max_severity,
+                "threat_summary": findings[0].summary,
+                "threat_names": sorted(
+                    {f.threat_category for f in findings if f.threat_category}
+                ),
+                "total_findings": len(findings),
+                "source_file": source_file,
+            }
+        },
+    }
+
+
+async def scan_source_with_yara(
+    source_path: str,
+    *,
+    rules_dir: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Run YARA rules over a source file or directory without any LLM call.
+
+    Args:
+        source_path: A source file or a directory to walk recursively.
+        rules_dir: Optional custom YARA rules directory.
+
+    Returns:
+        One result row per scanned file, including clean files (``is_safe``
+        ``True``) so the output enumerates everything that was examined
+        rather than only what matched. A file whose YARA scan raises is
+        reported with status ``error`` and severity ``ERROR`` rather than
+        being silently dropped or misreported as clean.
+
+    Raises:
+        FileNotFoundError: If ``source_path`` does not exist.
+    """
+    if not os.path.exists(source_path):
+        raise FileNotFoundError(f"Source path not found: {source_path}")
+
+    analyzer = YaraAnalyzer(rules_dir=rules_dir)
+
+    if os.path.isfile(source_path):
+        source_files = [source_path]
+    else:
+        source_files = await asyncio.to_thread(find_source_files, source_path)
+
+    logger.info(
+        "yara source scan start target=%s files=%d",
+        sanitize_log_value(source_path),
+        len(source_files),
+    )
+
+    results: List[Dict[str, Any]] = []
+    for source_file in source_files:
+        display_name = (
+            os.path.relpath(source_file, source_path)
+            if os.path.isdir(source_path)
+            else os.path.basename(source_file)
+        )
+
+        source_text = await asyncio.to_thread(_read_source_text, source_file)
+        if source_text is None:
+            continue
+
+        try:
+            findings = await analyzer.analyze(
+                source_text,
+                context={"tool_name": display_name, "content_type": "source_code"},
+            )
+        except Exception as exc:
+            # A rule-matching failure means this file was never examined.
+            # Reporting it as clean would make a gather failure
+            # indistinguishable from evidence of safety, so surface it.
+            logger.error(
+                "YARA scan failed for %s: %s", sanitize_log_value(source_file), exc
+            )
+            results.append(
+                {
+                    "tool_name": display_name,
+                    "tool_description": f"Source file {display_name}",
+                    "status": "error",
+                    "is_safe": False,
+                    "findings": {
+                        "yara_analyzer": {
+                            "severity": "ERROR",
+                            "threat_summary": f"YARA scan failed: {exc}",
+                            "threat_names": [],
+                            "total_findings": 0,
+                            "source_file": source_file,
+                        }
+                    },
+                }
+            )
+            continue
+
+        results.append(_result_for_file(display_name, source_file, findings))
+
+    if not results:
+        results.append(
+            {
+                "tool_name": "No source files found",
+                "tool_description": f"No supported source files under {source_path}",
+                "status": "completed",
+                "is_safe": True,
+                "findings": {},
+            }
+        )
+
+    matched = sum(1 for r in results if not r.get("is_safe", True))
+    logger.info(
+        "yara source scan done target=%s scanned=%d flagged=%d",
+        sanitize_log_value(source_path),
+        len(results),
+        matched,
+    )
+    return results

--- a/mcpscanner/core/source_scan.py
+++ b/mcpscanner/core/source_scan.py
@@ -74,8 +74,13 @@ def _read_source_text(path: str) -> Tuple[Optional[str], Optional[str]]:
         with open(path, "rb") as handle:
             return handle.read().decode("utf-8", errors="replace"), None
     except OSError as exc:
+        # ``exc`` embeds the offending filename, which is attacker-controlled
+        # for a scanned tree; sanitizing keeps a crafted name from forging
+        # fields in the structured ``key=value`` log line.
         logger.warning(
-            "source scan could not read %s: %s", sanitize_log_value(path), exc
+            "source scan could not read %s: %s",
+            sanitize_log_value(path),
+            sanitize_log_value(exc),
         )
         return None, str(exc)
 
@@ -209,9 +214,13 @@ async def scan_source_with_yara(
             )
         except Exception as exc:
             # Failure to gather evidence must not look like evidence of
-            # compliance, so the file is surfaced instead of dropped.
+            # compliance, so the file is surfaced instead of dropped. The
+            # exception text is sanitized because it can carry rule or file
+            # names from the scanned tree.
             logger.error(
-                "YARA scan failed for %s: %s", sanitize_log_value(source_file), exc
+                "YARA scan failed for %s: %s",
+                sanitize_log_value(source_file),
+                sanitize_log_value(exc),
             )
             results.append(
                 _row(

--- a/tests/test_source_scan.py
+++ b/tests/test_source_scan.py
@@ -77,6 +77,28 @@ def source_tree(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@pytest.fixture
+def rules_dir(tmp_path_factory) -> Path:
+    """A custom YARA rules directory whose single rule matches ``server.py``.
+
+    Naming the rule lets a test assert that custom rules were actually
+    loaded, rather than that the command merely exited zero.
+    """
+    d = tmp_path_factory.mktemp("rules")
+    (d / "custom.yar").write_text(
+        "rule custom_marker_rule {\n"
+        "  meta:\n"
+        '    description = "matches the fixture source tree"\n'
+        '    threat_type = "custom_marker"\n'
+        "  strings:\n"
+        '    $a = "def handler"\n'
+        "  condition:\n"
+        "    $a\n"
+        "}\n"
+    )
+    return d
+
+
 def _rows_by_name(results: list[dict]) -> dict[str, dict]:
     return {row["tool_name"]: row for row in results}
 
@@ -239,13 +261,71 @@ async def test_scan_surfaces_analyzer_failure_instead_of_passing(source_tree: Pa
     failed = rows["server.py"]
     assert failed["status"] == "error"
     assert failed["is_safe"] is False
-    assert failed["findings"]["yara_analyzer"]["severity"] == "ERROR"
+    assert failed["findings"]["yara_analyzer"]["severity"] == "UNKNOWN"
     assert (
         "rule matching blew up" in failed["findings"]["yara_analyzer"]["threat_summary"]
     )
 
     # One bad file must not abort the rest of the scan.
     assert rows[os.path.join("sub", "clean.py")]["is_safe"] is True
+
+
+@pytest.mark.asyncio
+async def test_scan_surfaces_unreadable_file_instead_of_omitting(source_tree: Path):
+    """A file that cannot be read is reported, not silently dropped.
+
+    Omitting it would let a permission-denied tree scan as clean.
+    """
+    target = str(source_tree / "server.py")
+
+    real_open = open
+
+    def deny(path, *args, **kwargs):
+        if str(path) == target:
+            raise PermissionError(13, "Permission denied")
+        return real_open(path, *args, **kwargs)
+
+    with patch("builtins.open", side_effect=deny):
+        results = await scan_source_with_yara(str(source_tree))
+
+    rows = _rows_by_name(results)
+    failed = rows["server.py"]
+    assert failed["status"] == "error"
+    assert failed["is_safe"] is False
+    assert failed["findings"]["yara_analyzer"]["severity"] == "UNKNOWN"
+    assert "could not be read" in failed["findings"]["yara_analyzer"]["threat_summary"]
+
+    # Readable siblings are still scanned.
+    assert rows[os.path.join("sub", "clean.py")]["is_safe"] is True
+
+
+@pytest.mark.asyncio
+async def test_unexaminable_severity_is_renderable(source_tree: Path):
+    """Error rows use a severity every formatter already knows how to render.
+
+    ``by_severity`` iterates a fixed ordering, so a bespoke severity would
+    drop the row and hide the very failure the error row exists to report.
+    """
+    from mcpscanner.core.report_generator import ReportGenerator
+    from mcpscanner.core.models import OutputFormat, SeverityFilter
+
+    async def boom(content, context=None):
+        raise RuntimeError("nope")
+
+    with patch(
+        "mcpscanner.core.analyzers.yara_analyzer.YaraAnalyzer.analyze",
+        side_effect=boom,
+    ):
+        results = await scan_source_with_yara(str(source_tree))
+
+    rendered = ReportGenerator(
+        {"server_url": "t", "scan_results": results}
+    ).format_output(
+        format_type=OutputFormat.BY_SEVERITY,
+        severity_filter=SeverityFilter.ALL,
+    )
+
+    assert "server.py" in rendered
 
 
 # ---------------------------------------------------------------------------
@@ -292,3 +372,66 @@ async def test_scan_skips_oversized_files(source_tree: Path):
 
     assert len(results) == 1
     assert results[0]["tool_name"] == "No source files found"
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "argv_tail",
+    [
+        ["static-source", "SRC", "--rules-path", "RULES"],
+        ["--rules-path", "RULES", "static-source", "SRC"],
+    ],
+    ids=["after-subcommand", "before-subcommand"],
+)
+async def test_cli_accepts_rules_path_either_side(
+    source_tree: Path, rules_dir: Path, argv_tail, capsys
+):
+    """``--rules-path`` works on both sides of the subcommand.
+
+    It is registered globally *and* on the subparser; the subparser uses
+    ``SUPPRESS`` so it cannot clobber a value given before the subcommand.
+    """
+    from mcpscanner.cli import main
+
+    argv = ["mcp-scanner"] + [
+        str(source_tree) if a == "SRC" else str(rules_dir) if a == "RULES" else a
+        for a in argv_tail
+    ]
+    # Raw output carries the matched rule name, so this asserts the custom
+    # rules were actually compiled rather than that the command merely exited.
+    argv += ["--format", "raw"]
+
+    with patch("sys.argv", argv):
+        await main()
+
+    assert "custom marker rule" in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_cli_credits_only_yara_in_table(source_tree: Path, capsys):
+    """``--format table`` must not report API/LLM as SAFE for this mode.
+
+    Neither analyzer runs here, so claiming a verdict for them would assert
+    a clean result from a check that never executed.
+    """
+    from mcpscanner.cli import main
+
+    argv = ["mcp-scanner", "static-source", str(source_tree), "--format", "table"]
+    with patch("sys.argv", argv):
+        await main()
+
+    rows = [
+        line
+        for line in capsys.readouterr().out.splitlines()
+        if "server.py" in line or "clean.py" in line
+    ]
+    assert rows, "expected at least one rendered result row"
+    # YARA ran, so it reports SAFE; API and LLM did not, so they must be N/A.
+    for row in rows:
+        assert "SAFE" in row
+        assert row.count("N/A") == 2

--- a/tests/test_source_scan.py
+++ b/tests/test_source_scan.py
@@ -1,0 +1,294 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the no-LLM YARA source scan (``mcp-scanner static-source``).
+
+The ``behavioral`` scan path pairs static analysis with an LLM alignment
+check and so cannot run without LLM credentials. These tests pin the
+contract of the pattern-only path:
+
+* it runs with **no** LLM provider key configured,
+* it enumerates clean files as well as matching ones, so a scan reports
+  what it examined rather than only what it flagged,
+* a file whose YARA scan raises is surfaced as an error rather than being
+  dropped or reported as clean, and
+* the traversal it shares with the behavioural analyzer still refuses to
+  follow symlinks that escape the scan root.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mcpscanner.core.analyzers.base import SecurityFinding
+from mcpscanner.core.source_discovery import find_source_files
+from mcpscanner.core.source_scan import scan_source_with_yara
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def source_tree(tmp_path: Path) -> Path:
+    """A small source tree with files that must and must not be scanned.
+
+    Layout::
+
+        root/
+          server.py               <- scanned
+          sub/clean.py            <- scanned
+          handler.ts              <- scanned (non-Python extension)
+          node_modules/dep.js     <- skipped (dependency tree)
+          __pycache__/cached.py   <- skipped (build artefact)
+          .hidden/secret.py       <- skipped (dot-directory)
+          notes.txt               <- skipped (unsupported extension)
+    """
+    (tmp_path / "server.py").write_text("def handler():\n    return 1\n")
+    (tmp_path / "handler.ts").write_text("export function h() { return 1; }\n")
+
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "clean.py").write_text("VALUE = 2\n")
+
+    for skipped_dir in ("node_modules", "__pycache__", ".hidden"):
+        d = tmp_path / skipped_dir
+        d.mkdir()
+        (d / "dep.py").write_text("SHOULD_NOT_BE_SCANNED = True\n")
+        (d / "dep.js").write_text("// should not be scanned\n")
+
+    (tmp_path / "notes.txt").write_text("not source\n")
+    return tmp_path
+
+
+def _rows_by_name(results: list[dict]) -> dict[str, dict]:
+    return {row["tool_name"]: row for row in results}
+
+
+# ---------------------------------------------------------------------------
+# Source discovery
+# ---------------------------------------------------------------------------
+
+
+def test_find_source_files_selects_supported_extensions(source_tree: Path):
+    """Python and tree-sitter-supported extensions are picked up."""
+    found = {
+        os.path.relpath(p, source_tree) for p in find_source_files(str(source_tree))
+    }
+
+    assert "server.py" in found
+    assert os.path.join("sub", "clean.py") in found
+    assert "handler.ts" in found
+
+
+def test_find_source_files_skips_artefacts_and_unsupported(source_tree: Path):
+    """Dependency trees, build artefacts, dot-dirs and non-source are skipped."""
+    found = {
+        os.path.relpath(p, source_tree) for p in find_source_files(str(source_tree))
+    }
+
+    assert not any(
+        part in name
+        for name in found
+        for part in ("node_modules", "__pycache__", ".hidden")
+    )
+    assert "notes.txt" not in found
+
+
+def test_find_source_files_rejects_symlink_escaping_root(tmp_path: Path):
+    """A symlink whose target is outside the scan root is not returned.
+
+    This is the shared-traversal half of the symlink-traversal hardening;
+    the no-LLM path must not become a way to read arbitrary files.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.py"
+    secret.write_text("SECRET = 'do not read'\n")
+
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "normal.py").write_text("OK = True\n")
+    try:
+        (root / "escape.py").symlink_to(secret)
+    except (OSError, NotImplementedError):  # pragma: no cover - platform dependent
+        pytest.skip("symlinks not supported on this platform")
+
+    found = find_source_files(str(root))
+
+    assert any(name.endswith("normal.py") for name in found)
+    assert not any(name.endswith("escape.py") for name in found)
+    assert not any("secret.py" in name for name in found)
+
+
+# ---------------------------------------------------------------------------
+# Scanning: no LLM credentials required
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scan_runs_without_llm_credentials(source_tree: Path, monkeypatch):
+    """The scan completes with every LLM-related env var cleared.
+
+    This is the regression that matters: the pattern-only path must not
+    reach the alignment client, which raises ``ValueError`` when no
+    provider key is configured.
+    """
+    for var in (
+        "MCP_SCANNER_LLM_API_KEY",
+        "MCP_SCANNER_LLM_MODEL",
+        "MCP_SCANNER_LLM_BASE_URL",
+        "AWS_BEARER_TOKEN_BEDROCK",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    results = await scan_source_with_yara(str(source_tree))
+
+    assert results, "scan should report the files it examined"
+    assert all("yara_analyzer" in row["findings"] for row in results)
+
+
+@pytest.mark.asyncio
+async def test_scan_enumerates_clean_files_as_safe(source_tree: Path):
+    """Files with no rule match appear as SAFE rather than being omitted.
+
+    A scan that only listed matches would make "examined and clean"
+    indistinguishable from "never examined".
+    """
+    results = await scan_source_with_yara(str(source_tree))
+    rows = _rows_by_name(results)
+
+    assert "server.py" in rows
+    clean_row = rows["server.py"]
+    assert clean_row["is_safe"] is True
+    assert clean_row["status"] == "completed"
+    assert clean_row["findings"]["yara_analyzer"]["severity"] == "SAFE"
+    assert clean_row["findings"]["yara_analyzer"]["total_findings"] == 0
+
+
+@pytest.mark.asyncio
+async def test_scan_reports_matches_as_unsafe(source_tree: Path):
+    """A rule match yields an unsafe row carrying the finding's severity."""
+    finding = SecurityFinding(
+        severity="HIGH",
+        summary="Detected 1 threat: script injection",
+        analyzer="YARA",
+        threat_category="INJECTION ATTACK",
+        details={"tool_name": "server.py"},
+    )
+
+    async def fake_analyze(content, context=None):
+        # Only the top-level server.py "matches"; everything else is clean.
+        if context and context.get("tool_name") == "server.py":
+            return [finding]
+        return []
+
+    with patch(
+        "mcpscanner.core.analyzers.yara_analyzer.YaraAnalyzer.analyze",
+        side_effect=fake_analyze,
+    ):
+        results = await scan_source_with_yara(str(source_tree))
+
+    rows = _rows_by_name(results)
+    assert rows["server.py"]["is_safe"] is False
+    analyzer_data = rows["server.py"]["findings"]["yara_analyzer"]
+    assert analyzer_data["severity"] == "HIGH"
+    assert analyzer_data["threat_names"] == ["INJECTION ATTACK"]
+    assert analyzer_data["total_findings"] == 1
+
+    # Clean siblings are still enumerated alongside the match.
+    assert rows[os.path.join("sub", "clean.py")]["is_safe"] is True
+
+
+@pytest.mark.asyncio
+async def test_scan_surfaces_analyzer_failure_instead_of_passing(source_tree: Path):
+    """A file whose scan raises is reported as an error, never as clean.
+
+    Swallowing the exception and emitting a SAFE row would make a failure
+    to gather evidence look like evidence of safety.
+    """
+
+    async def boom(content, context=None):
+        if context and context.get("tool_name") == "server.py":
+            raise RuntimeError("rule matching blew up")
+        return []
+
+    with patch(
+        "mcpscanner.core.analyzers.yara_analyzer.YaraAnalyzer.analyze",
+        side_effect=boom,
+    ):
+        results = await scan_source_with_yara(str(source_tree))
+
+    rows = _rows_by_name(results)
+    failed = rows["server.py"]
+    assert failed["status"] == "error"
+    assert failed["is_safe"] is False
+    assert failed["findings"]["yara_analyzer"]["severity"] == "ERROR"
+    assert (
+        "rule matching blew up" in failed["findings"]["yara_analyzer"]["threat_summary"]
+    )
+
+    # One bad file must not abort the rest of the scan.
+    assert rows[os.path.join("sub", "clean.py")]["is_safe"] is True
+
+
+# ---------------------------------------------------------------------------
+# Scanning: input shapes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scan_accepts_single_file(source_tree: Path):
+    """A file path scans just that file, regardless of its extension filter."""
+    target = source_tree / "server.py"
+    results = await scan_source_with_yara(str(target))
+
+    assert len(results) == 1
+    assert results[0]["tool_name"] == "server.py"
+
+
+@pytest.mark.asyncio
+async def test_scan_empty_directory_reports_no_files(tmp_path: Path):
+    """An empty tree yields an explicit placeholder row, not an empty list."""
+    results = await scan_source_with_yara(str(tmp_path))
+
+    assert len(results) == 1
+    assert results[0]["tool_name"] == "No source files found"
+    assert results[0]["is_safe"] is True
+
+
+@pytest.mark.asyncio
+async def test_scan_missing_path_raises(tmp_path: Path):
+    """A nonexistent path is a caller error, surfaced as FileNotFoundError."""
+    missing = tmp_path / "definitely-not-here"
+
+    with pytest.raises(FileNotFoundError):
+        await scan_source_with_yara(str(missing))
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_oversized_files(source_tree: Path):
+    """Files past the size ceiling are skipped rather than read into memory."""
+    with patch(
+        "mcpscanner.core.source_scan.MCPScannerConstants.MAX_FILE_SIZE_BYTES", 1
+    ):
+        results = await scan_source_with_yara(str(source_tree))
+
+    assert len(results) == 1
+    assert results[0]["tool_name"] == "No source files found"

--- a/tests/test_source_scan.py
+++ b/tests/test_source_scan.py
@@ -30,6 +30,7 @@ contract of the pattern-only path:
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -299,6 +300,65 @@ async def test_scan_surfaces_unreadable_file_instead_of_omitting(source_tree: Pa
     assert rows[os.path.join("sub", "clean.py")]["is_safe"] is True
 
 
+# Whitespace, ``=`` and quotes would let a crafted filename or rule name forge
+# extra fields in the structured ``key=value`` operator log.
+_LOG_INJECTION = 'boom=1 "q"'
+_LOG_INJECTION_SANITIZED = "boom_1__q_"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["read", "analyze"])
+async def test_failure_logs_sanitize_exception_text(
+    source_tree: Path, caplog, failure: str
+):
+    """Exception text reaches the log sanitized, not raw.
+
+    Both failure paths interpolate the exception into an operator log line.
+    The text is derived from the scanned tree (filenames, rule names), so it
+    is attacker-controlled and must not be able to inject log fields.
+    """
+    target = str(source_tree / "server.py")
+    real_open = open
+
+    def deny(path, *args, **kwargs):
+        if str(path) == target:
+            raise PermissionError(13, _LOG_INJECTION)
+        return real_open(path, *args, **kwargs)
+
+    async def boom(content, context=None):
+        if context and context.get("tool_name") == "server.py":
+            raise RuntimeError(_LOG_INJECTION)
+        return []
+
+    if failure == "read":
+        ctx = patch("builtins.open", side_effect=deny)
+    else:
+        ctx = patch(
+            "mcpscanner.core.analyzers.yara_analyzer.YaraAnalyzer.analyze",
+            side_effect=boom,
+        )
+
+    with caplog.at_level(logging.WARNING, logger="mcpscanner.core.source_scan"):
+        with ctx:
+            results = await scan_source_with_yara(str(source_tree))
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "mcpscanner.core.source_scan"
+    ]
+    injected = [m for m in messages if _LOG_INJECTION_SANITIZED in m]
+    assert injected, f"expected a sanitized failure log, got {messages}"
+    for message in injected:
+        assert _LOG_INJECTION not in message
+
+    # Sanitizing the log must not blank the machine-readable report field.
+    summary = _rows_by_name(results)["server.py"]["findings"]["yara_analyzer"][
+        "threat_summary"
+    ]
+    assert _LOG_INJECTION in summary
+
+
 @pytest.mark.asyncio
 async def test_unexaminable_severity_is_renderable(source_tree: Path):
     """Error rows use a severity every formatter already knows how to render.
@@ -417,7 +477,9 @@ async def test_cli_credits_only_yara_in_table(source_tree: Path, capsys):
     """``--format table`` must not report API/LLM as SAFE for this mode.
 
     Neither analyzer runs here, so claiming a verdict for them would assert
-    a clean result from a check that never executed.
+    a clean result from a check that never executed. Checked per column: a
+    row-wide substring check would also pass if API reported ``SAFE`` while
+    YARA reported ``N/A`` (and ``"SAFE" in row`` is even true of ``UNSAFE``).
     """
     from mcpscanner.cli import main
 
@@ -425,13 +487,19 @@ async def test_cli_credits_only_yara_in_table(source_tree: Path, capsys):
     with patch("sys.argv", argv):
         await main()
 
+    # Columns are whitespace-padded and no cell here contains a space, so
+    # positional split gives target, tool, status, API, YARA, LLM, severity.
     rows = [
-        line
+        line.split()
         for line in capsys.readouterr().out.splitlines()
-        if "server.py" in line or "clean.py" in line
+        if line.startswith("static-source:")
     ]
-    assert rows, "expected at least one rendered result row"
-    # YARA ran, so it reports SAFE; API and LLM did not, so they must be N/A.
+    assert {row[1] for row in rows} == {
+        "server.py",
+        "handler.ts",
+        os.path.join("sub", "clean.py"),
+    }
     for row in rows:
-        assert "SAFE" in row
-        assert row.count("N/A") == 2
+        api, yara, llm = row[3], row[4], row[5]
+        # YARA ran and found nothing; the two that never ran must say N/A.
+        assert (api, yara, llm) == ("N/A", "SAFE", "N/A"), row


### PR DESCRIPTION
## Context

Closes #171. Closes #170.

Both issues describe the same gap from two angles: the README advertises
"Behavioural Code Scanning: Scan Source code of MCP servers for finding threats"
and lists `yara_analyzer` as an independently usable engine, but there is no way
to run pattern detection over source without an LLM provider key.

Reproduced on `main` (4.8.3):

```
$ mcp-scanner --analyzer-filter yara_analyzer behavioral ./src
Error during scanning: LLM provider API key is required for alignment verification
```

The cause is that `--analyzer-filter` is a **report-time** filter
(`report_generator.py:325`), not a runtime one. `BehavioralCodeAnalyzer`
unconditionally constructs an `AlignmentOrchestrator`, whose `AlignmentLLMClient`
raises when no provider key is configured (`alignment_llm_client.py:120`). So the
filter is applied long after the analyzer that needs the key was already built,
and the YARA-only path advertised in the README is unreachable.

## Description

Adds a `static-source` subcommand — the name suggested in #171 — that runs the
existing YARA rules directly over a source file or directory, with no LLM
provider and no running MCP server.

`static` reads pre-captured `tools/list` JSON; `behavioral` reads source but
requires an LLM key. This fills the remaining cell: reads source, needs neither.

Three things worth flagging for review:

**No LLM SDK on the import path.** Importing `BehavioralCodeAnalyzer` to reuse
its directory walk pulls in `litellm` transitively — I measured ~11s and ~880
modules — which would defeat the point of a no-LLM path. So traversal moved to a
new dependency-light `core/source_discovery.py` that both callers share.
`BehavioralCodeAnalyzer._find_source_files` now delegates to it, and the
extension maps are sourced from it, so the two paths cannot drift on which files
count as source. Behaviour there is unchanged.

(Note: `mcpscanner.cli` still imports `litellm` eagerly via the package
`__init__` chain — ~18s on `main` before this branch. Pre-existing and left
alone, but it does mean `static-source` still pays that startup cost today. Happy
to look at deferring it in a separate PR if useful.)

**Clean files are reported, not omitted.** Every scanned file gets a row,
including matches-free ones (`"is_safe": true`, severity `SAFE`). A report
listing only matches would make "examined and clean" indistinguishable from
"never examined".

**A failed scan is not a pass.** If YARA raises on a file, that row is emitted
with status `error` and severity `ERROR` rather than being dropped or defaulted
to clean, and the rest of the scan continues.

Symlink-escape filtering is preserved — the shared traversal keeps
`filter_safe_paths`, so `static-source` cannot be used to read files outside the
scan root. There is a regression test for this.

## Steps to review

```bash
# Reproduce the gap on main first
mcp-scanner --analyzer-filter yara_analyzer behavioral ./some_src   # errors

# Then on this branch, with no LLM key set at all:
unset MCP_SCANNER_LLM_API_KEY
mcp-scanner static-source ./some_src
mcp-scanner static-source ./some_src/server.py --format raw
mcp-scanner static-source ./some_src --rules-path ./custom_rules/
```

Verified locally: all output formats (`summary`, `raw`, `detailed`, `by_tool`,
`by_analyzer`, `by_severity`, `table`), single-file and directory input, empty
directory, missing path (exits 1 with a clean message), `node_modules` /
`__pycache__` / dot-directory skipping, and symlink-escape rejection.

Tests: 11 new tests in `tests/test_source_scan.py`, all passing. Full suite is
1258 passed / 11 skipped, with 4 failures that also fail on unmodified `main`
(`test_prefilter_zero_marker_file_is_fast`,
`test_scan_instructions_api_endpoint`, and the two
`*_synthetic_session_terminated` scanner tests) plus one collection error in
`test_oauth_example_redirects.py` from a missing `mcp.server.fastmcp` — all
pre-existing and unrelated.

New files are `black`-formatted. I deliberately did not reformat the 48
pre-existing files that `black --check` flags on `main`, to keep this diff
reviewable.

## Checklist

- [x] Tests added for the new behaviour (including the failed-scan and
      symlink-escape cases)
- [x] No change in behaviour for existing scan paths
- [x] README updated: documents `static-source`, and notes that `behavioral`
      always requires an LLM key — the expectation mismatch #171 reported
- [x] No new dependencies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `static-source` command for YARA-based source scanning without an LLM key or running server.
  * Supports individual files or directories, custom rules, detailed output, verbosity, output files, and CI-friendly raw formats.
  * Clearly reports clean, flagged, missing, oversized, and unreadable files.
  * Excludes dependency, build, hidden, and unsafe symlink paths.

* **Documentation**
  * Added usage examples and clarified the difference between `static-source` scanning and behavioral analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->