### PR TITLE
perf: import litellm lazily so LLM-free paths don't pay for it

### DIFF
--- a/mcpscanner/core/analyzers/behavioral/alignment/alignment_llm_client.py
+++ b/mcpscanner/core/analyzers/behavioral/alignment/alignment_llm_client.py
@@ -31,7 +31,7 @@ import itertools
 import logging
 import time
 
-from litellm import acompletion
+from .....utils.lazy_litellm import acompletion
 
 from .....config.config import Config
 from .....config.constants import MCPScannerConstants

--- a/mcpscanner/core/analyzers/llm_analyzer.py
+++ b/mcpscanner/core/analyzers/llm_analyzer.py
@@ -24,7 +24,8 @@ import asyncio
 import json
 import secrets
 from typing import Any, Dict, List, Optional
-from litellm import acompletion
+
+from ...utils.lazy_litellm import acompletion
 
 from ...config.config import Config
 from ...config.constants import MCPScannerConstants

--- a/mcpscanner/core/analyzers/meta_analyzer.py
+++ b/mcpscanner/core/analyzers/meta_analyzer.py
@@ -45,7 +45,7 @@ import secrets
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Dict, List, Optional, Tuple
 
-from litellm import acompletion
+from ...utils.lazy_litellm import acompletion
 
 from ...config.config import Config
 from ...config.constants import MCPScannerConstants

--- a/mcpscanner/core/analyzers/readiness/llm_judge.py
+++ b/mcpscanner/core/analyzers/readiness/llm_judge.py
@@ -36,20 +36,13 @@ import os
 from typing import Any, Dict, List, Optional
 
 from ....config.constants import MCPScannerConstants
+from ....utils.lazy_litellm import (
+    acompletion,
+    is_litellm_available as _litellm_is_available,
+    litellm_import_error as _litellm_error_reason,
+)
 from ....utils.logging_config import get_logger
 from ..base import SecurityFinding
-
-# Try to import litellm
-_litellm_available = False
-_litellm_import_error: Optional[str] = None
-
-try:
-    from litellm import acompletion
-
-    _litellm_available = True
-except ImportError as e:
-    _litellm_import_error = str(e)
-    acompletion = None  # type: ignore
 
 
 # Readiness-specific threat categories
@@ -140,7 +133,7 @@ class ReadinessLLMJudge:
         Returns:
             True if the LLM judge can be used, False otherwise.
         """
-        if not _litellm_available:
+        if not _litellm_is_available():
             return False
 
         # Require API key to be set
@@ -153,8 +146,8 @@ class ReadinessLLMJudge:
         Returns:
             Human-readable explanation or None if available.
         """
-        if not _litellm_available:
-            return f"litellm not installed: {_litellm_import_error}"
+        if not _litellm_is_available():
+            return f"litellm not installed: {_litellm_error_reason()}"
 
         if not self.api_key:
             return (

--- a/mcpscanner/utils/lazy_litellm.py
+++ b/mcpscanner/utils/lazy_litellm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Cisco Systems, Inc. and its affiliates
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mcpscanner/utils/lazy_litellm.py
+++ b/mcpscanner/utils/lazy_litellm.py
@@ -1,0 +1,80 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deferred access to ``litellm``.
+
+Importing ``litellm`` pulls in ~1700 extra modules (openai, tokenizers,
+httpx internals, ...) and dominates process startup. Analyzer modules
+only need it when a request is actually issued, but a module-level
+``from litellm import acompletion`` makes every importer of
+``mcpscanner`` pay that cost up front --- including ``mcp-scanner --help``
+and the subcommands that never call an LLM.
+
+This module exposes a thin passthrough that imports ``litellm`` on first
+*call* instead of at import time. Analyzer modules do::
+
+    from ...utils.lazy_litellm import acompletion
+
+and keep calling ``await acompletion(...)`` unchanged.
+
+``acompletion`` is deliberately declared with ``async def`` rather than a
+plain ``def`` that returns litellm's coroutine. ``unittest.mock.patch``
+chooses its replacement class by calling
+:func:`asyncio.iscoroutinefunction` on the target: a coroutine function
+is replaced with :class:`~unittest.mock.AsyncMock`, anything else with a
+:class:`~unittest.mock.MagicMock` whose return value cannot be awaited.
+The existing suite patches these names in bare form
+(``@patch("...llm_analyzer.acompletion")``) and then awaits the call, so a
+plain ``def`` here breaks those tests with "object MagicMock can't be
+used in 'await' expression". Keep this an ``async def``.
+"""
+
+from importlib import import_module, util
+from typing import Any, Optional
+
+__all__ = ["acompletion", "is_litellm_available", "litellm_import_error"]
+
+
+async def acompletion(*args: Any, **kwargs: Any) -> Any:
+    """Await ``litellm.acompletion``, importing ``litellm`` on first use.
+
+    Args:
+        *args: Positional arguments forwarded verbatim to ``litellm.acompletion``.
+        **kwargs: Keyword arguments forwarded verbatim to ``litellm.acompletion``.
+
+    Returns:
+        Whatever ``litellm.acompletion`` resolves to.
+    """
+    return await import_module("litellm").acompletion(*args, **kwargs)
+
+
+def is_litellm_available() -> bool:
+    """Return whether ``litellm`` can be imported, without importing it.
+
+    Uses :func:`importlib.util.find_spec`, which locates the module
+    without executing it, so an availability probe stays cheap.
+    """
+    try:
+        return util.find_spec("litellm") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def litellm_import_error() -> Optional[str]:
+    """Return a human-readable reason ``litellm`` is unavailable, else ``None``."""
+    if is_litellm_available():
+        return None
+    return "No module named 'litellm'"

--- a/tests/test_lazy_litellm.py
+++ b/tests/test_lazy_litellm.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Guards for the deferred ``litellm`` import.
+
+``litellm`` pulls in ~1700 extra modules, so importing ``mcpscanner`` must
+not drag it in: every subcommand (and ``--help``) pays that cost otherwise.
+
+The import-graph assertions run in a **subprocess** on purpose. Once any
+test in this session touches an LLM analyzer, ``litellm`` is in the parent
+process's ``sys.modules`` for good, so an in-process check would pass
+whether or not the production import path is lazy.
+"""
+
+import asyncio
+import subprocess
+import sys
+import types
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mcpscanner.utils.lazy_litellm import (
+    acompletion,
+    is_litellm_available,
+    litellm_import_error,
+)
+
+
+def _import_probe(module: str) -> subprocess.CompletedProcess:
+    """Import ``module`` in a clean interpreter and report litellm's presence."""
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import importlib, sys;"
+                f"importlib.import_module({module!r});"
+                "print('litellm' in sys.modules)"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "mcpscanner",
+        "mcpscanner.cli",
+        "mcpscanner.core.analyzers.llm_analyzer",
+        "mcpscanner.core.analyzers.meta_analyzer",
+        "mcpscanner.core.analyzers.readiness.llm_judge",
+        "mcpscanner.core.analyzers.behavioral.alignment.alignment_llm_client",
+    ],
+)
+def test_importing_module_does_not_import_litellm(module: str) -> None:
+    """Importing any analyzer entry point must not pull in ``litellm``."""
+    proc = _import_probe(module)
+    assert proc.returncode == 0, f"import of {module} failed:\n{proc.stderr}"
+    assert proc.stdout.strip() == "False", (
+        f"importing {module} eagerly imported litellm; keep the import inside "
+        f"mcpscanner.utils.lazy_litellm.acompletion.\nstderr:\n{proc.stderr}"
+    )
+
+
+def test_acompletion_is_a_coroutine_function() -> None:
+    """``acompletion`` must stay ``async def``.
+
+    ``unittest.mock.patch`` picks its replacement class from
+    ``iscoroutinefunction``: a coroutine function becomes an ``AsyncMock``,
+    anything else a ``MagicMock`` whose return value cannot be awaited. The
+    suite patches these names in bare form and awaits the result, so a plain
+    ``def`` here would break those tests.
+    """
+    assert asyncio.iscoroutinefunction(acompletion)
+
+
+def test_acompletion_forwards_arguments_and_result() -> None:
+    """The wrapper is a passthrough: args in, litellm's return value out.
+
+    A stub module is injected into ``sys.modules`` rather than patching
+    ``importlib.import_module`` itself: that function is used by the import
+    system and by ``asyncio``, so replacing it globally breaks unrelated
+    machinery mid-test.
+    """
+    sentinel = object()
+    fake = AsyncMock(return_value=sentinel)
+
+    stub = types.ModuleType("litellm")
+    stub.acompletion = fake  # type: ignore[attr-defined]
+
+    with patch.dict(sys.modules, {"litellm": stub}):
+        result = asyncio.run(acompletion(model="gpt-4o", messages=[], api_key="k"))
+
+    fake.assert_awaited_once_with(model="gpt-4o", messages=[], api_key="k")
+    assert result is sentinel
+
+
+def test_availability_probe_does_not_import_litellm() -> None:
+    """``is_litellm_available`` uses ``find_spec``, so it must not execute litellm."""
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys;"
+                "from mcpscanner.utils.lazy_litellm import is_litellm_available;"
+                "avail = is_litellm_available();"
+                "print(avail, 'litellm' in sys.modules)"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    available, imported = proc.stdout.split()
+    assert available == "True", "litellm is a project dependency; expected available"
+    assert imported == "False", "availability probe must not import litellm"
+
+
+def test_import_error_reason_is_none_when_available() -> None:
+    """With litellm installed there is no unavailability reason to report."""
+    assert is_litellm_available() is True
+    assert litellm_import_error() is None


### PR DESCRIPTION
## Summary

`litellm` is imported at module scope in four analyzer modules, all of which are reachable from `mcpscanner/core/analyzers/__init__.py`. Because `mcpscanner/__init__.py` imports that package, **every** importer of `mcpscanner` pays the full `litellm` import — including `mcp-scanner --help` and the subcommands that never call an LLM.

This defers the import to the first actual call, behind a small shared helper (`mcpscanner/utils/lazy_litellm.py`). Call sites keep using `await acompletion(...)` unchanged.

Follow-up to a side observation on #234; opening separately as requested.

## Why four files, not one

Fixing a single module doesn't help — whichever of these loads first pulls `litellm` in for the whole process:

- `core/analyzers/llm_analyzer.py`
- `core/analyzers/meta_analyzer.py`
- `core/analyzers/readiness/llm_judge.py`
- `core/analyzers/behavioral/alignment/alignment_llm_client.py`

`readiness/llm_judge.py` already had the right instinct (`try: from litellm import ... except ImportError`), but a `try/except` still *executes* the import. It now uses `importlib.util.find_spec`, which locates the module without executing it, so `is_available()` / `get_unavailable_reason()` keep their existing semantics at no import cost.

## Measurements

A/B against unmodified `main` (`893327c`) via `git worktree`, same interpreter, alternating runs.

| | `main` | this branch |
|---|---|---|
| modules after `import mcpscanner.cli` | 2552 | **832** |
| peak RSS | 228 MB | **73 MB** |
| `--help` wall clock | 17.7–18.5 s | **4.5–5.2 s** |

`--help` output is byte-identical in both arms (9539 chars, exit 0).

One caveat on the wall-clock column: my machine was under load (~5.0, an unrelated process pinning a core), so the absolute seconds are inflated and shouldn't be read as representative. The ratio held across 5 alternating pairs, and the module-count and RSS figures are load-independent — those are the numbers I'd trust. `litellm`, `openai`, and `tokenizers` are all absent from the import graph after this change.

## Tests

`tests/test_lazy_litellm.py` (10 tests). The import-graph assertions run in a **subprocess** on purpose: once any test in a session touches an LLM analyzer, `litellm` is in the parent's `sys.modules` for good, and an in-process check would pass whether or not the production path is lazy.

Full suite: **1262 passed, 11 skipped** (1253 on `main` + 10 new, and see the note below for the 1 deselected).

One design note worth flagging for review, since it's load-bearing and easy to undo by accident: `acompletion` must stay `async def`. `unittest.mock.patch` picks its replacement class via `iscoroutinefunction` — a coroutine function becomes an `AsyncMock`, anything else a `MagicMock` whose return value can't be awaited. The suite patches these names in bare form (`@patch("...llm_analyzer.acompletion")`) and awaits the result, so a plain `def` wrapper breaks 4 existing tests with `object MagicMock can't be used in 'await' expression`. I hit exactly that on my first attempt; there's a comment in the module and a guard test so the next person doesn't.

## Not touched

`tests/static_analysis/test_capability_extraction_perf.py::test_prefilter_zero_marker_file_is_fast` asserts a wall-clock budget (`elapsed < 50` ms) and fails on my machine under load. I checked whether this branch caused it: both `native_analyzer.py` and that test file are byte-identical to `main`, and A/B under identical load shows `main` failing it too (median 69–76 ms, 8–9 of 9 runs over budget) while this branch measures marginally *faster*. So it's a pre-existing machine-speed-dependent threshold, not a regression here — I've left it alone and deselected it in the run above rather than fix an unrelated test in a perf PR. Happy to open a separate issue if you'd like it made load-independent (e.g. asserting the prefilter short-circuits rather than timing it).

I also deliberately did **not** run `black` across the three analyzer files I edited. They were already not black-clean on `main`, and every hunk the formatter wants is in pre-existing code (Bedrock auth branches, timeout logic) — reformatting would bury a 4-line import change in unrelated churn. My two new files are black-clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - AI-powered scanning components now load the optional AI integration only when needed.
  - The application can start and use non-AI functionality even when the AI integration is unavailable.
  - Improved reporting explains when the AI integration cannot be loaded.
  - AI requests now use more consistent model settings and transient-error handling, improving reliability.
  - Alignment checks support configurable retry limits.

- **Tests**
  - Added coverage confirming deferred loading, availability checks, asynchronous requests, and clear error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->