### PR TITLE
docs: rename "LLM-as-a-judge" to "LLM-based analysis" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![Cisco AI Defense](https://img.shields.io/badge/Cisco-AI%20Defense-049fd9?logo=cisco&logoColor=white)](https://www.cisco.com/site/us/en/products/security/ai-defense/index.html)
 [![AI Security and Safety Framework](https://img.shields.io/badge/AI%20Security-Framework-orange)](https://learn-cloudsecurity.cisco.com/ai-security-framework)
 
-A Python tool for scanning MCP (Model Context Protocol) servers and tools for potential security findings. The MCP Scanner combines Cisco AI Defense inspect API, YARA rules and LLM-as-a-judge to detect malicious MCP tools.
+A Python tool for scanning MCP (Model Context Protocol) servers and tools for potential security findings. The MCP Scanner combines Cisco AI Defense inspect API, YARA rules and LLM-based analysis to detect malicious MCP tools.
 
 ## Overview
 
-The MCP Scanner provides a comprehensive solution for scanning MCP servers and tools for security findings. It leverages three powerful scanning engines (Yara, LLM-as-judge, Cisco AI Defense) that can be used together or independently.
+The MCP Scanner provides a comprehensive solution for scanning MCP servers and tools for security findings. It leverages three powerful scanning engines (Yara, LLM-based analysis, Cisco AI Defense) that can be used together or independently.
 
 The SDK is designed to be easy to use while providing powerful scanning capabilities, flexible authentication options, and customization.
 


### PR DESCRIPTION
The README described one of the scanning engines as "LLM-as-a-judge." That term has a specific, established meaning: using an LLM to evaluate or score the output of another system against some criteria. The engine in question does not do that — it reads raw MCP tool metadata and classifies it as malicious or safe, i.e. LLM-based detection/analysis.

By the standard definition, the component that actually fits "LLM-as-a-judge" is the meta-analyzer, which reviews the other analyzers' findings. To avoid confusing readers now that the project is open source, this renames the engine to "LLM-based analysis" in the two README references. Docs-only change; no code, class, enum, or CLI-flag names are affected (the code already calls it LLMAnalyzer).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README overview to describe LLM-based analysis using clearer terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->