### PR TITLE
fix(cli): restore environment override flags

### DIFF
--- a/mcpscanner/cli.py
+++ b/mcpscanner/cli.py
@@ -2374,7 +2374,6 @@ async def main():
                 sys.exit(1)
 
         elif args.cmd == "vulnerable-package":
-            import os
             from mcpscanner.core.analyzers.vulnerable_package_analyzer import VulnerablePackageAnalyzer
             from mcpscanner.config.constants import MCPScannerConstants as CONSTANTS
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@
 
 import pytest
 import json
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import patch, AsyncMock, MagicMock
@@ -611,6 +612,31 @@ class TestStaticSubcommandCLI:
             assert "MCP Scanner Results" in captured.out
             assert "Total tools scanned: 1" in captured.out
             assert "Safe items: 1" in captured.out
+
+    @pytest.mark.asyncio
+    async def test_api_key_flag_is_applied_before_static_dispatch(
+        self, tools_json_file, monkeypatch, capsys
+    ):
+        """Global CLI environment overrides are applied before subcommand dispatch."""
+        from mcpscanner.cli import main
+
+        monkeypatch.delenv("MCP_SCANNER_API_KEY", raising=False)
+        test_args = [
+            "mcp-scanner",
+            "--api-key",
+            "test-api-key",
+            "--analyzers",
+            "yara",
+            "static",
+            "--tools",
+            tools_json_file,
+        ]
+
+        with patch("sys.argv", test_args):
+            await main()
+
+        assert "MCP Scanner Results" in capsys.readouterr().out
+        assert os.environ["MCP_SCANNER_API_KEY"] == "test-api-key"
 
     @pytest.mark.asyncio
     async def test_static_resources_result_conversion(self, resources_json_file):


### PR DESCRIPTION
## Description

I removed the function-local `os` import that shadowed the module import in `main()`. Global CLI overrides now set their environment variables before the selected scan command runs.

Fixes #251

## Verification

- Before: `mcp-scanner --api-key X --analyzers yara static --tools /dev/null` raised `UnboundLocalError` before scanning.
- After: the same command accepts the flag and reaches static scanning; `/dev/null` is then rejected as an empty target.
- Added a real `main()` regression case covering `--api-key` through static dispatch and the resulting environment override.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the global API key option is applied before the static scan command runs, so scans can reliably use the supplied API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->