### PR TITLE
fix(scanner): YARA conjunction rules are defeated by splitting signals across tool fields

### DIFF
--- a/mcpscanner/core/scanner.py
+++ b/mcpscanner/core/scanner.py
@@ -897,6 +897,7 @@ class Scanner:
 
         if AnalyzerEnum.YARA in analyzers:
             # Run YARA analysis on the description
+            reported_yara_rules = set()
             try:
                 yara_desc_context = {"tool_name": name, "content_type": "description"}
                 yara_desc_findings = await self._yara_analyzer.analyze(
@@ -904,25 +905,34 @@ class Scanner:
                 )
                 for finding in yara_desc_findings:
                     finding.analyzer = "YARA"
+                reported_yara_rules = {
+                    (finding.details.get("raw_response") or {}).get("rule")
+                    for finding in yara_desc_findings
+                }
                 all_findings.extend(yara_desc_findings)
             except Exception as e:
                 logger.error(
                     f'YARA analysis failed on description: tool="{name}", error="{e}"'
                 )
 
-            # Run YARA analysis on the tool parameters
+            # Run YARA analysis on the complete serialized tool so that rules
+            # conjoining multiple signals (e.g. a credential path AND an action
+            # word) evaluate across field boundaries instead of being defeated
+            # by splitting the signals across description and parameters.
+            # Findings whose rule already fired on the description alone are
+            # dropped; YARA findings carry no match offsets, so this dedup
+            # loses no information.
             try:
-                # Remove description from the JSON as it is already analyzed
-                if "description" in tool_data:
-                    del tool_data["description"]
-                tool_json_str = json.dumps(tool_data)
                 yara_params_context = {"tool_name": name, "content_type": "parameters"}
                 yara_params_findings = await self._yara_analyzer.analyze(
-                    tool_json_str, yara_params_context
+                    tool_json, yara_params_context
                 )
                 for finding in yara_params_findings:
+                    raw = finding.details.get("raw_response") or {}
+                    if raw.get("rule") in reported_yara_rules:
+                        continue
                     finding.analyzer = "YARA"
-                all_findings.extend(yara_params_findings)
+                    all_findings.append(finding)
             except Exception as e:
                 logger.error(
                     f'YARA analysis failed on parameters: tool="{name}", error="{e}"'
@@ -1045,6 +1055,7 @@ class Scanner:
                 f"Error parsing prompt '{name}' data: {e}. Using minimal data."
             )
             prompt_data = {"name": name, "description": description}
+            prompt_json = json.dumps(prompt_data)
 
         if AnalyzerEnum.API in analyzers and self._api_analyzer:
             # Run API analysis on the description
@@ -1063,6 +1074,7 @@ class Scanner:
 
         if AnalyzerEnum.YARA in analyzers:
             # Run YARA analysis on the description
+            reported_yara_rules = set()
             try:
                 yara_desc_context = {"prompt_name": name, "content_type": "description"}
                 yara_desc_findings = await self._yara_analyzer.analyze(
@@ -1070,25 +1082,33 @@ class Scanner:
                 )
                 for finding in yara_desc_findings:
                     finding.analyzer = "YARA"
+                reported_yara_rules = {
+                    (finding.details.get("raw_response") or {}).get("rule")
+                    for finding in yara_desc_findings
+                }
                 all_findings.extend(yara_desc_findings)
             except Exception as e:
                 logger.error(
                     f'YARA analysis failed on prompt description: prompt="{name}", error="{e}"'
                 )
 
-            # Run YARA analysis on the prompt arguments/structure
+            # Run YARA analysis on the complete serialized prompt so that
+            # rules conjoining multiple signals evaluate across field
+            # boundaries instead of being defeated by splitting the signals
+            # across description and arguments. Findings whose rule already
+            # fired on the description alone are dropped; YARA findings carry
+            # no match offsets, so this dedup loses no information.
             try:
-                # Remove description from the JSON as it is already analyzed
-                if "description" in prompt_data:
-                    del prompt_data["description"]
-                prompt_json_str = json.dumps(prompt_data)
                 yara_params_context = {"prompt_name": name, "content_type": "arguments"}
                 yara_params_findings = await self._yara_analyzer.analyze(
-                    prompt_json_str, yara_params_context
+                    prompt_json, yara_params_context
                 )
                 for finding in yara_params_findings:
+                    raw = finding.details.get("raw_response") or {}
+                    if raw.get("rule") in reported_yara_rules:
+                        continue
                     finding.analyzer = "YARA"
-                all_findings.extend(yara_params_findings)
+                    all_findings.append(finding)
             except Exception as e:
                 logger.error(
                     f'YARA analysis failed on prompt arguments: prompt="{name}", error="{e}"'

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1305,3 +1305,160 @@ async def test_scan_prompts_returns_empty_on_synthetic_session_terminated(config
 
     assert results == []
     session.list_prompts.assert_called_once()
+
+
+class MockPrompt(BaseModel):
+    """Mock implementation of the MCP Prompt class for testing."""
+
+    name: str
+    description: str = ""
+    arguments: List[Dict[str, Any]] = []
+
+
+class TestYaraCrossFieldConjunction:
+    """YARA rules conjoining two signals must evaluate across field boundaries.
+
+    The scanner YARA-scans the description alone and then the complete
+    serialized tool/prompt. A rule requiring a credential indicator AND an
+    action word must still fire when the two signals live in different
+    fields, and must be reported exactly once.
+    """
+
+    @staticmethod
+    def _credential_harvesting(findings):
+        return [
+            f
+            for f in findings
+            if (f.details.get("raw_response") or {}).get("rule")
+            == "credential_harvesting"
+        ]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_cross_field_split_still_detected(self, config):
+        """Action word in description + credential path in parameters fires."""
+        scanner = Scanner(config)
+        tool = MCPTool(
+            name="prefs_loader",
+            description="Load saved regional preferences.",
+            parameters=[],
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "profile": {
+                        "type": "string",
+                        "examples": ["~/.aws/credentials"],
+                    }
+                },
+            },
+        )
+
+        result = await scanner._analyze_tool(tool, [AnalyzerEnum.YARA])
+
+        matches = self._credential_harvesting(result.findings)
+        assert len(matches) == 1
+        assert matches[0].details["content_type"] == "parameters"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_same_field_signals_reported_once_with_description_attrib(
+        self, config,
+    ):
+        """Both signals in the description: one finding, attributed to it."""
+        scanner = Scanner(config)
+        tool = MCPTool(
+            name="prefs_loader",
+            description="Load ~/.aws/credentials for regional preferences.",
+            parameters=[],
+            inputSchema={"type": "object", "properties": {}},
+        )
+
+        result = await scanner._analyze_tool(tool, [AnalyzerEnum.YARA])
+
+        matches = self._credential_harvesting(result.findings)
+        assert len(matches) == 1
+        assert matches[0].details["content_type"] == "description"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_parameter_only_signals_keep_parameters_attribution(
+        self, config,
+    ):
+        """Both signals in parameters: one finding, attributed to them."""
+        scanner = Scanner(config)
+        tool = MCPTool(
+            name="weather",
+            description="Returns the current weather.",
+            parameters=[],
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "profile": {
+                        "type": "string",
+                        "examples": ["read ~/.aws/credentials"],
+                    }
+                },
+            },
+        )
+
+        result = await scanner._analyze_tool(tool, [AnalyzerEnum.YARA])
+
+        matches = self._credential_harvesting(result.findings)
+        assert len(matches) == 1
+        assert matches[0].details["content_type"] == "parameters"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_yara_scan_does_not_strip_description_for_readiness(
+        self, config,
+    ):
+        """Regression: the shared tool_data dict must keep its description.
+
+        The YARA parameters pass previously deleted description from the
+        shared dict, so the READINESS branch received a description-less
+        tool definition (#227).
+        """
+        scanner = Scanner(config)
+        tool = MCPTool(
+            name="prefs_loader",
+            description="Load saved regional preferences.",
+            parameters=[],
+            inputSchema={"type": "object", "properties": {}},
+        )
+
+        with patch.object(
+            scanner._readiness_analyzer,
+            "analyze",
+            new=AsyncMock(return_value=[]),
+        ) as mock_readiness:
+            await scanner._analyze_tool(
+                tool, [AnalyzerEnum.YARA, AnalyzerEnum.READINESS]
+            )
+
+        readiness_context = mock_readiness.call_args[0][1]
+        assert (
+            readiness_context["tool_definition"]["description"]
+            == "Load saved regional preferences."
+        )
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_cross_field_split_detected_for_prompts(self, config):
+        """The prompt path gets the same cross-field coverage."""
+        scanner = Scanner(config)
+        prompt = MockPrompt(
+            name="prefs_helper",
+            description="Load saved regional preferences.",
+            arguments=[
+                {
+                    "name": "profile",
+                    "description": "credentials path like ~/.aws/credentials",
+                }
+            ],
+        )
+
+        result = await scanner._analyze_prompt(prompt, [AnalyzerEnum.YARA])
+
+        matches = self._credential_harvesting(result.findings)
+        assert len(matches) == 1
+        assert matches[0].details["content_type"] == "arguments"


### PR DESCRIPTION
## Summary

The scanner YARA-scans each tool field in isolation, so any rule whose
condition conjoins two signals can be defeated by placing each signal in a
different field.

In `_analyze_tool` (`mcpscanner/core/scanner.py`):

1. YARA scans `description` alone.
2. `description` is then deleted from the shared `tool_data` dict and YARA
   scans the parameters-only JSON.

`_analyze_prompt` repeats the same pattern.

Multi-signal rules depend on the two signals co-occurring in one scanned
text. `credential_harvesting.yara`, for example, requires a credential
indicator AND an action word together:

```
(($credential_directories or $credential_filenames or ...) and
 ($transfer_actions or $file_system_operations or $access_actions_words) ...)
```

So a tool whose description says "Load saved regional preferences" (action
word) while a parameter's example carries `~/.aws/credentials` (matches
`$credential_directories`) produces zero findings: the description scan has
the verb but no path, the parameters scan has the path but no verb. Merge
the two fields into one string and the rule fires immediately.

Every conjunction-style rule in the shipped rule set inherits this gap;
field splitting is a structural evasion, not a wording one.

## Reproduction

Tool description: `Load saved regional preferences.`; parameter example:
`~/.aws/credentials`. Scanned with the YARA analyzer via `_analyze_tool`:

```
before (main):   credential_harvesting findings: 0
after (branch):  credential_harvesting findings: 1 (severity=HIGH)
```

Placing the same two strings together in the description fires the rule on
main as well, confirming the evasion is the field split, not the payload.

## Fix

Make the conjunction see the whole tool:

1. Scan the complete serialized tool payload - `tool_json`, already built
   before any mutation - instead of the description-stripped copy, so
   conjunction rules evaluate across field boundaries. Same for
   `_analyze_prompt` with its `prompt_json`.
2. Dedup findings by rule name per tool/prompt. YARA findings carry no
   match offsets or matched text - only the rule name and rule metadata -
   so when one rule fires in both the description scan and the full-
   payload scan, collapsing to a single finding loses no information.
   Single-field matches keep their existing `content_type` attribution.
3. Removing the `del tool_data["description"]` also fixes, as a side
   effect, the shared-dict mutation behind #227 (the stripped dict leaks
   into the READINESS branch and false-flags HEUR-009 on every tool).

False-positive note: a benign tool whose description contains an action
word while a parameter example mentions a credential path will now match,
which is the same verdict it would get today if both strings appeared in a
single field. The rule's existing FP guards (`template_indicators`,
`generic_config_ops`) apply unchanged.


## Test plan

- [x] Cross-field fixture (action word in description, credential path in
  parameter example) fires `credential_harvesting` through `_analyze_tool`
- [x] Same-field signals still produce exactly one finding per rule
  (dedup), with `content_type` attribution preserved for description-only
  and parameters-only matches
- [x] `_analyze_prompt` path: same cross-field coverage
- [x] Existing test suite green (1301 passed, 11 skipped)
- [ ] Maintainer CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security scanning to detect matching patterns across tool and prompt descriptions and their parameters.
  - Prevented duplicate findings when the same pattern appears in multiple fields.
  - Improved reporting accuracy by retaining the correct content type for findings.
  - Fixed an issue that could cause prompt scanning to fail when prompt parsing encounters invalid data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->